### PR TITLE
Bump version to 0.21.0-pre.2 to match burn

### DIFF
--- a/crates/burn-flex/Cargo.toml
+++ b/crates/burn-flex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "burn-flex"
-version = "0.0.1"
+version = "0.21.0-pre.2"
 edition.workspace = true
 license.workspace = true
 description = "A fast, portable CPU backend for Burn"


### PR DESCRIPTION
## Summary
- Align burn-flex version (0.21.0-pre.2) with the burn dependency version
- Crate name `burn-flex` has been reserved on crates.io at v0.0.1

## Test plan
- [ ] Verify `cargo check` passes