### PR TITLE
perf: conv weight transpose fix, fused softmax/layer_norm, and candle bench coverage

### DIFF
--- a/BENCHMARKS_CANDLE.md
+++ b/BENCHMARKS_CANDLE.md
@@ -18,9 +18,23 @@ version**: 0.10 (pinned in `crates/burn-flex-bench-candle/Cargo.toml`) **Burn-fl
 ## Running
 
 ```sh
+# Original wav2vec2-focused benches
 cargo bench -p burn-flex-bench-candle --bench matmul
 cargo bench -p burn-flex-bench-candle --bench conv1d
 cargo bench -p burn-flex-bench-candle --bench transformer_ops
+
+# Broader op coverage (added 2026-04-05)
+cargo bench -p burn-flex-bench-candle --bench elementwise
+cargo bench -p burn-flex-bench-candle --bench reduce
+cargo bench -p burn-flex-bench-candle --bench shape_ops
+cargo bench -p burn-flex-bench-candle --bench matmul_batched
+cargo bench -p burn-flex-bench-candle --bench conv2d
+cargo bench -p burn-flex-bench-candle --bench pool2d
+cargo bench -p burn-flex-bench-candle --bench indexing
+cargo bench -p burn-flex-bench-candle --bench misc_ops
+
+# Or everything
+cargo bench -p burn-flex-bench-candle
 ```
 
 ---
@@ -144,6 +158,171 @@ transformer layer runs softmax + 2× layer_norm × 24 layers.
 The rest of the forward pass (matmul, gelu, attention) is tied or a small flex win, so the 4.7 ms
 wallclock savings from just these three op families drives the overall wav2vec2-large inference
 advantage vs candle on the same hardware.
+
+---
+
+## Broader op coverage (added 2026-04-05)
+
+Eight additional bench files in `crates/burn-flex-bench-candle/benches/` cover every flex op that
+intersects with candle's CPU API. Medians below are from a single fresh run on the same Apple M3
+Max. Ratios use candle / flex (>1.0 means flex is faster).
+
+### Batched matmul (attention shapes)
+
+| Shape                                         | Flex       | Candle  | Ratio     |
+| --------------------------------------------- | ---------- | ------- | --------- |
+| QK^T `[16, 50, 64] @ [16, 64, 50]`            | **52 µs**  | 74 µs   | **1.40×** |
+| QK^T `[16, 150, 64] @ [16, 64, 150]`          | **190 µs** | 1.61 ms | **8.47×** |
+| AV `[16, 50, 50] @ [16, 50, 64]`              | 58 µs      | 58 µs   | tied      |
+| AV `[16, 150, 150] @ [16, 150, 64]`           | **173 µs** | 1.59 ms | **9.19×** |
+| batched_128 `[32, 128, 128] @ [32, 128, 128]` | **253 µs** | 3.29 ms | **13.0×** |
+
+Flex's batched matmul delegates to gemm crate per-batch; candle's 3D matmul path does not call a
+blocked gemm at 3D, so it loses dramatically as batch×inner gets larger.
+
+Caveat: the view-input form `q.matmul(k.swap_dims(1,2))` currently regresses flex at small seqs (340
+µs at seq=50 vs 83 µs for candle, and vs 52 µs for flex's own contiguous path). Tracked in the perf
+bug list below.
+
+### Conv2d + conv_transpose2d (ResNet shapes)
+
+| Layer                         | Flex        | Candle  | Ratio        |
+| ----------------------------- | ----------- | ------- | ------------ |
+| resnet_conv1 1×3×224² k7 s2   | **872 µs**  | 1.10 ms | **1.27×**    |
+| resnet_l1 1×64×56² k3         | **942 µs**  | 1.28 ms | **1.36×**    |
+| resnet_l2 1×128×28² k3        | **1.03 ms** | 1.90 ms | **1.85×**    |
+| resnet_l3 1×256×14² k3        | **1.47 ms** | 2.20 ms | **1.49×**    |
+| resnet_l4 1×512×7² k3         | **2.35 ms** | 3.08 ms | **1.31×**    |
+| 1×1 pointwise 1×256×56² → 64  | 2.23 ms     | 1.52 ms | 0.68×        |
+| conv_transpose 1×128×16² → 64 | **12.5 ms** | 1.45 ms | **0.12×** ⚠️ |
+| conv_transpose 1×64×32² → 32  | **10.6 ms** | 1.30 ms | **0.12×** ⚠️ |
+
+Flex wins every standard 3×3 conv2d layer; 1×1 pointwise is where candle's direct gemm is sharper.
+`conv_transpose2d` is a major outlier (8× slower) and is listed in the perf bug list.
+
+### Pool2d
+
+| Shape          | Op  | Flex       | Candle  | Ratio     |
+| -------------- | --- | ---------- | ------- | --------- |
+| 1×64×112² k3s2 | max | **436 µs** | 893 µs  | **2.05×** |
+| 1×64×112² k3s2 | avg | **471 µs** | 896 µs  | **1.90×** |
+| 8×64×56² k3s2  | max | **684 µs** | 1.81 ms | **2.64×** |
+| 8×64×56² k3s2  | avg | **766 µs** | 1.75 ms | **2.29×** |
+| 1×128×28² k2s2 | max | 92 µs      | 57 µs   | 0.62×     |
+| 1×128×28² k2s2 | avg | 89 µs      | 56 µs   | 0.63×     |
+
+Flex wins the common k=3 stride=2 ResNet pool by ~2×; loses on the tiny k=2 shapes, which are near
+the divan noise floor (<100 µs).
+
+### Reductions
+
+| Op              | Shape | Flex        | Candle  | Ratio     |
+| --------------- | ----- | ----------- | ------- | --------- |
+| sum (full)      | 1024² | 52.6 µs     | 47.8 µs | 0.91×     |
+| mean (full)     | 1024² | 48.5 µs     | 48.0 µs | tied      |
+| max (full)      | 1024² | **129 µs**  | 520 µs  | **4.0×**  |
+| min (full)      | 1024² | **129 µs**  | 520 µs  | **4.0×**  |
+| sum_dim last    | 1024² | 78.2 µs     | 40.4 µs | 0.52×     |
+| sum_dim first   | 1024² | **78.4 µs** | 1.20 ms | **15.3×** |
+| mean_dim last   | 1024² | 77.6 µs     | 40.8 µs | 0.53×     |
+| max_dim last    | 1024² | 3.37 ms     | 506 µs  | 0.15×     |
+| max_dim first   | 1024² | 3.35 ms     | 911 µs  | 0.27×     |
+| argmax_dim last | 1024² | 3.40 ms     | 911 µs  | 0.27×     |
+
+Two big wins: **4× faster full-tensor max/min** (candle routes via `flatten_all → max(0)`) and **15×
+faster non-last-dim sum** (candle is missing a SIMD strided reducer). Two real losses: **sum_dim /
+mean_dim last-axis** is 2× slower on flex, and **max_dim / argmax_dim** is 4× slower regardless of
+axis. Both are listed in the perf bug list.
+
+### Elementwise (1D, 1M elements, f32)
+
+All basic arithmetic and transcendentals land within 5% on both backends (both bottleneck on LPDDR5
+bandwidth at roughly 56 GB/s for the cheap ops). Representative numbers at 1M:
+
+| Op    | Flex     | Candle   |
+| ----- | -------- | -------- |
+| add   | 112.6 µs | 112.8 µs |
+| mul   | 112.7 µs | 112.8 µs |
+| neg   | 74.6 µs  | 76.7 µs  |
+| recip | 74.3 µs  | 74.2 µs  |
+| sqrt  | 139 µs   | 142 µs   |
+| log   | 1.69 ms  | 1.69 ms  |
+| tanh  | 1.73 ms  | 1.73 ms  |
+| powf  | 3.01 ms  | 3.11 ms  |
+| sin   | 1.41 ms  | 1.27 ms  |
+
+The only notable gap is `sin` at ~10% slower on flex.
+
+### Shape ops
+
+View ops (transpose, reshape, narrow, expand, permute) are all under 150 ns on both backends;
+differences are pure dispatch overhead and not meaningful.
+
+Data-moving shape ops:
+
+| Op                                 | Flex        | Candle  | Ratio     |
+| ---------------------------------- | ----------- | ------- | --------- |
+| transpose_then_exp 1024² (strided) | **1.29 ms** | 2.14 ms | **1.65×** |
+| cat along dim 0, 2×1024²           | 101 µs      | 109 µs  | 1.08×     |
+| cat along last dim, 2×1024²        | **121 µs**  | 322 µs  | **2.66×** |
+| repeat_dim 256² ×4                 | 13.1 µs     | 13.0 µs | tied      |
+
+Flex's strided-unary path handles transposed inputs 1.65× faster than candle, and its last-axis
+`cat` is 2.66× faster (candle's per-row stride copy is the bottleneck).
+
+### Indexing
+
+| Shape | Op                 | Flex       | Candle | Ratio     |
+| ----- | ------------------ | ---------- | ------ | --------- |
+| 1024² | gather last dim    | **244 µs** | 511 µs | **2.09×** |
+| 1024² | scatter_add last   | 548 µs     | 622 µs | 1.13×     |
+| 1024² | index_select dim 0 | 100 µs     | 36 µs  | 0.36× ⚠️  |
+| 1024² | where_cond         | 248 µs     | 122 µs | 0.49× ⚠️  |
+
+Flex wins gather (the hottest indexing op in language models) by 2×; loses `index_select` and
+`mask_where` by ~2×.
+
+### Cumsum, sort, nearest2d
+
+| Op                            | Flex         | Candle  | Ratio     |
+| ----------------------------- | ------------ | ------- | --------- |
+| cumsum last dim, 256²         | **42 µs**    | 436 µs  | **10.4×** |
+| cumsum last dim, 1024²        | **696 µs**   | 4.68 ms | **6.72×** |
+| sort last dim, 256²           | 202 µs       | 186 µs  | tied      |
+| sort last dim, 1024²          | **11.95 ms** | 1.54 ms | 0.13× ⚠️  |
+| nearest2d upsample 64² → 128² | 56 µs        | 30 µs   | 0.54×     |
+
+Cumsum is one of the biggest flex wins (6–10×). Sort ties at 256² but scales poorly to 1024² (8×
+slower, listed below).
+
+---
+
+## Perf bug list (prioritized)
+
+Surfaced by the broader coverage pass. Ordered by impact on real workloads.
+
+1. **conv_transpose2d: 8× slower** (12.5 ms vs 1.45 ms). Largest single gap. Affects any model with
+   an upsampling decoder (segmentation, GAN, super-resolution).
+2. **sort_last at 1024²: 7.8× slower** (12 ms vs 1.5 ms). Ties at 256² then regresses sharply as
+   rows grow.
+3. **max_dim / argmax_dim: ~4× slower** (3.4 ms vs ~900 µs at 1024²). On the classifier output path
+   for any model with an argmax head.
+4. **matmul on transposed-view input at small seqs: 4× slower than candle, 6× slower than flex's own
+   contiguous path**. `Q @ K.swap_dims(1,2)` at `[16, 50, 64]` takes 340 µs on flex vs 52 µs for the
+   contiguous-input form. Affects any attention kernel written in the idiomatic transpose form.
+5. **conv1d L3–L6 (small wav2vec2 shapes): 1.2–1.5× slower**. Already tracked at
+   [antimora/burn-flex#34](https://github.com/antimora/burn-flex/issues/34).
+6. **index_select: 2.8× slower** (100 µs vs 36 µs). Pure row-copy; should be memcpy-bound.
+7. **where_cond / mask_where: 2× slower** (248 µs vs 122 µs). Elementwise select.
+8. **sum_dim / mean_dim along last axis: ~2× slower** (78 µs vs 40 µs at 1024²). Minor but sits on
+   the fused-layer_norm dependency path.
+9. **nearest2d upsample: ~2× slower** (56 µs vs 30 µs). Low absolute cost.
+10. **conv2d 1×1 pointwise: 1.5× slower** (2.23 ms vs 1.52 ms). Candle takes a direct gemm path for
+    pointwise; flex's im2col adds overhead.
+
+Items 1–4 together cover decoder models, classifiers, and any attention not written in the
+pre-transposed-K form. Fixing them would move flex into a "wins everywhere" state against candle on
+this hardware.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -125,8 +125,33 @@ the decomposed 5-6-op default path in burn-tensor / burn-nn; there is an
 [upstream proposal](crates/burn-flex-bench-candle/UPSTREAM_ISSUE.md) to add fused `softmax` and
 `layer_norm` hooks to burn-backend so any CPU backend can plug in.
 
+#### Broader op coverage
+
+Eleven bench files now cover every flex op that intersects with candle's CPU API (elementwise,
+reduce, shape ops, batched matmul, conv2d, pool2d, indexing, cumsum, sort, interpolate). Selected
+highlights on the same hardware:
+
+| Op                                | Shape                                  | Flex         | Candle   | Flex vs Candle |
+| --------------------------------- | -------------------------------------- | ------------ | -------- | -------------- |
+| batched matmul (attention)        | `[32, 128, 128] @ [32, 128, 128]`      | **253 µs**   | 3.29 ms  | **13.0×**      |
+| batched matmul (AV, 3s)           | `[16, 150, 150] @ [16, 150, 64]`       | **173 µs**   | 1.59 ms  | **9.19×**      |
+| conv2d ResNet layer 2             | 1×128×28² k=3                          | **1.03 ms**  | 1.90 ms  | **1.85×**      |
+| max_pool2d k=3 s=2                | 8×64×56²                               | **684 µs**   | 1.81 ms  | **2.64×**      |
+| cumsum last dim                   | 256×256                                | **42 µs**    | 436 µs   | **10.4×**      |
+| full-tensor max / min             | 1024²                                  | **129 µs**   | 520 µs   | **4.0×**       |
+| sum along non-last dim            | 1024²                                  | **78 µs**    | 1.20 ms  | **15.3×**      |
+| gather last dim                   | 1024², half-index                      | **244 µs**   | 511 µs   | **2.09×**      |
+| cat along last dim                | 2×1024²                                | **121 µs**   | 322 µs   | **2.66×**      |
+| basic elementwise (add/mul/...)   | 1M f32                                 | 112 µs       | 112 µs   | tied (BW-bound)|
+
+Ties cover all basic elementwise arithmetic, transcendentals, view ops (transpose/reshape/narrow),
+square matmul, and gelu. Ten specific regressions vs candle are documented and prioritized as a
+perf bug list in [BENCHMARKS_CANDLE.md](BENCHMARKS_CANDLE.md#perf-bug-list-prioritized). The biggest
+are `conv_transpose2d` (8× slower, upsampling decoders), `sort_last` at large rows (8× slower), and
+`max_dim`/`argmax_dim` (4× slower, affects classifier output paths).
+
 See [BENCHMARKS_CANDLE.md](BENCHMARKS_CANDLE.md) for the full breakdown including conv1d L1-L6, all
-transformer shapes, and per-forward-pass estimates.
+transformer shapes, per-forward-pass estimates, and the complete bench output.
 
 ### Status
 

--- a/crates/burn-flex-bench-candle/Cargo.toml
+++ b/crates/burn-flex-bench-candle/Cargo.toml
@@ -33,3 +33,35 @@ harness = false
 [[bench]]
 name = "transformer_ops"
 harness = false
+
+[[bench]]
+name = "elementwise"
+harness = false
+
+[[bench]]
+name = "reduce"
+harness = false
+
+[[bench]]
+name = "shape_ops"
+harness = false
+
+[[bench]]
+name = "matmul_batched"
+harness = false
+
+[[bench]]
+name = "conv2d"
+harness = false
+
+[[bench]]
+name = "pool2d"
+harness = false
+
+[[bench]]
+name = "indexing"
+harness = false
+
+[[bench]]
+name = "misc_ops"
+harness = false

--- a/crates/burn-flex-bench-candle/benches/conv2d.rs
+++ b/crates/burn-flex-bench-candle/benches/conv2d.rs
@@ -1,0 +1,240 @@
+//! conv2d + conv_transpose2d vs candle (pure Rust).
+//!
+//! Run with:
+//! ```bash
+//! cargo bench -p burn-flex-bench-candle --bench conv2d
+//! ```
+//!
+//! Shapes mirror common image-model building blocks (ResNet early/mid layers)
+//! so the numbers are meaningful for vision workloads, not only audio.
+
+use burn_flex::Flex;
+use burn_tensor::{
+    Tensor, TensorData, module,
+    ops::{ConvOptions, ConvTransposeOptions},
+};
+use candle_core::{Device as CandleDevice, Tensor as CandleTensor};
+use divan::{AllocProfiler, Bencher};
+
+#[global_allocator]
+static ALLOC: AllocProfiler = AllocProfiler::system();
+
+fn main() {
+    println!("Conv2d: burn-flex vs candle (pure Rust)");
+    println!();
+    divan::main();
+}
+
+fn fill(n: usize) -> Vec<f32> {
+    (0..n).map(|i| ((i % 1000) as f32 / 1000.0) - 0.5).collect()
+}
+
+fn flex_input(b: usize, c: usize, h: usize, w: usize) -> Tensor<Flex, 4> {
+    Tensor::from_data(
+        TensorData::new(fill(b * c * h * w), [b, c, h, w]),
+        &Default::default(),
+    )
+}
+fn flex_kernel(oc: usize, ic: usize, kh: usize, kw: usize) -> Tensor<Flex, 4> {
+    Tensor::from_data(
+        TensorData::new(fill(oc * ic * kh * kw), [oc, ic, kh, kw]),
+        &Default::default(),
+    )
+}
+fn candle_input(b: usize, c: usize, h: usize, w: usize) -> CandleTensor {
+    CandleTensor::from_vec(fill(b * c * h * w), (b, c, h, w), &CandleDevice::Cpu).unwrap()
+}
+fn candle_kernel(oc: usize, ic: usize, kh: usize, kw: usize) -> CandleTensor {
+    CandleTensor::from_vec(
+        fill(oc * ic * kh * kw),
+        (oc, ic, kh, kw),
+        &CandleDevice::Cpu,
+    )
+    .unwrap()
+}
+
+#[derive(Copy, Clone)]
+struct Conv {
+    name: &'static str,
+    b: usize,
+    ic: usize,
+    h: usize,
+    w: usize,
+    oc: usize,
+    k: usize,
+    stride: usize,
+    padding: usize,
+}
+
+impl std::fmt::Display for Conv {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.name)
+    }
+}
+
+// Square 3x3 kernels, single padding value. ResNet-ish.
+const LAYERS: &[Conv] = &[
+    Conv {
+        name: "resnet_conv1_k7_s2",
+        b: 1,
+        ic: 3,
+        h: 224,
+        w: 224,
+        oc: 64,
+        k: 7,
+        stride: 2,
+        padding: 3,
+    },
+    Conv {
+        name: "resnet_l1_64x56",
+        b: 1,
+        ic: 64,
+        h: 56,
+        w: 56,
+        oc: 64,
+        k: 3,
+        stride: 1,
+        padding: 1,
+    },
+    Conv {
+        name: "resnet_l2_128x28",
+        b: 1,
+        ic: 128,
+        h: 28,
+        w: 28,
+        oc: 128,
+        k: 3,
+        stride: 1,
+        padding: 1,
+    },
+    Conv {
+        name: "resnet_l3_256x14",
+        b: 1,
+        ic: 256,
+        h: 14,
+        w: 14,
+        oc: 256,
+        k: 3,
+        stride: 1,
+        padding: 1,
+    },
+    Conv {
+        name: "resnet_l4_512x7",
+        b: 1,
+        ic: 512,
+        h: 7,
+        w: 7,
+        oc: 512,
+        k: 3,
+        stride: 1,
+        padding: 1,
+    },
+    // 1x1 pointwise — almost pure gemm, useful to confirm matmul-dominated path.
+    Conv {
+        name: "pointwise_1x1_256x56",
+        b: 1,
+        ic: 256,
+        h: 56,
+        w: 56,
+        oc: 64,
+        k: 1,
+        stride: 1,
+        padding: 0,
+    },
+];
+
+#[divan::bench_group(name = "flex/conv2d")]
+mod flex_conv2d {
+    use super::*;
+    #[divan::bench(args = LAYERS)]
+    fn conv2d(bencher: Bencher, l: &Conv) {
+        let x = flex_input(l.b, l.ic, l.h, l.w);
+        let w = flex_kernel(l.oc, l.ic, l.k, l.k);
+        let opts = ConvOptions::new([l.stride, l.stride], [l.padding, l.padding], [1, 1], 1);
+        bencher.bench(|| module::conv2d(x.clone(), w.clone(), None, opts.clone()));
+    }
+}
+#[divan::bench_group(name = "candle/conv2d")]
+mod candle_conv2d {
+    use super::*;
+    #[divan::bench(args = LAYERS)]
+    fn conv2d(bencher: Bencher, l: &Conv) {
+        let x = candle_input(l.b, l.ic, l.h, l.w);
+        let w = candle_kernel(l.oc, l.ic, l.k, l.k);
+        bencher.bench(|| x.conv2d(&w, l.padding, l.stride, 1, 1).unwrap());
+    }
+}
+
+// ============================================================================
+// conv_transpose2d — upsampling layer common in segmentation / GAN decoders.
+// ============================================================================
+
+#[derive(Copy, Clone)]
+struct ConvT {
+    name: &'static str,
+    b: usize,
+    ic: usize,
+    h: usize,
+    w: usize,
+    oc: usize,
+    k: usize,
+    stride: usize,
+}
+
+impl std::fmt::Display for ConvT {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.name)
+    }
+}
+
+const CT_LAYERS: &[ConvT] = &[
+    ConvT {
+        name: "deconv_128_to_256",
+        b: 1,
+        ic: 128,
+        h: 16,
+        w: 16,
+        oc: 64,
+        k: 4,
+        stride: 2,
+    },
+    ConvT {
+        name: "deconv_64_to_128",
+        b: 1,
+        ic: 64,
+        h: 32,
+        w: 32,
+        oc: 32,
+        k: 4,
+        stride: 2,
+    },
+];
+
+#[divan::bench_group(name = "flex/conv_transpose2d")]
+mod flex_convt {
+    use super::*;
+    #[divan::bench(args = CT_LAYERS)]
+    fn conv_t(bencher: Bencher, l: &ConvT) {
+        let x = flex_input(l.b, l.ic, l.h, l.w);
+        // conv_transpose weight layout is [in_ch, out_ch, kh, kw] in burn.
+        let w = flex_kernel(l.ic, l.oc, l.k, l.k);
+        let opts = ConvTransposeOptions::new([l.stride, l.stride], [1, 1], [0, 0], [1, 1], 1);
+        bencher.bench(|| module::conv_transpose2d(x.clone(), w.clone(), None, opts.clone()));
+    }
+}
+#[divan::bench_group(name = "candle/conv_transpose2d")]
+mod candle_convt {
+    use super::*;
+    #[divan::bench(args = CT_LAYERS)]
+    fn conv_t(bencher: Bencher, l: &ConvT) {
+        let x = candle_input(l.b, l.ic, l.h, l.w);
+        // candle uses [in_ch, out_ch, kh, kw] for conv_transpose too.
+        let w = candle_kernel(l.ic, l.oc, l.k, l.k);
+        bencher.bench(|| {
+            x.conv_transpose2d(
+                &w, /*padding*/ 1, /*output_padding*/ 0, l.stride, 1,
+            )
+            .unwrap()
+        });
+    }
+}

--- a/crates/burn-flex-bench-candle/benches/elementwise.rs
+++ b/crates/burn-flex-bench-candle/benches/elementwise.rs
@@ -1,0 +1,420 @@
+//! Elementwise ops: unary, binary, comparison vs candle (pure Rust).
+//!
+//! Run with:
+//! ```bash
+//! cargo bench -p burn-flex-bench-candle --bench elementwise
+//! ```
+
+use burn_flex::Flex;
+use burn_tensor::{Tensor, TensorData};
+use candle_core::{Device as CandleDevice, Tensor as CandleTensor};
+use divan::{AllocProfiler, Bencher};
+
+#[global_allocator]
+static ALLOC: AllocProfiler = AllocProfiler::system();
+
+fn main() {
+    println!("Elementwise: burn-flex vs candle (pure Rust)");
+    println!();
+    divan::main();
+}
+
+/// [0.1, 1.1) — safe for log/sqrt/recip.
+fn fill_pos(n: usize) -> Vec<f32> {
+    (0..n).map(|i| 0.1 + (i % 1000) as f32 / 1000.0).collect()
+}
+
+/// [-0.5, 0.5) — signed values for generic ops.
+fn fill_signed(n: usize) -> Vec<f32> {
+    (0..n).map(|i| ((i % 1000) as f32 / 1000.0) - 0.5).collect()
+}
+
+fn flex_1d_pos(n: usize) -> Tensor<Flex, 1> {
+    Tensor::from_data(TensorData::new(fill_pos(n), [n]), &Default::default())
+}
+
+fn flex_1d(n: usize) -> Tensor<Flex, 1> {
+    Tensor::from_data(TensorData::new(fill_signed(n), [n]), &Default::default())
+}
+
+fn candle_1d_pos(n: usize) -> CandleTensor {
+    CandleTensor::from_vec(fill_pos(n), n, &CandleDevice::Cpu).unwrap()
+}
+
+fn candle_1d(n: usize) -> CandleTensor {
+    CandleTensor::from_vec(fill_signed(n), n, &CandleDevice::Cpu).unwrap()
+}
+
+/// Sizes: transformer-ish (50k ~= seq=50 * hidden=1024) and a full 1M.
+const SIZES: &[usize] = &[50 * 1024, 150 * 1024, 1024 * 1024];
+
+// ============================================================================
+// Unary
+// ============================================================================
+
+#[divan::bench_group(name = "flex/exp")]
+mod flex_exp {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn exp(bencher: Bencher, n: &usize) {
+        let x = flex_1d(*n);
+        bencher.bench(|| x.clone().exp());
+    }
+}
+#[divan::bench_group(name = "candle/exp")]
+mod candle_exp {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn exp(bencher: Bencher, n: &usize) {
+        let x = candle_1d(*n);
+        bencher.bench(|| x.exp().unwrap());
+    }
+}
+
+#[divan::bench_group(name = "flex/log")]
+mod flex_log {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn log(bencher: Bencher, n: &usize) {
+        let x = flex_1d_pos(*n);
+        bencher.bench(|| x.clone().log());
+    }
+}
+#[divan::bench_group(name = "candle/log")]
+mod candle_log {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn log(bencher: Bencher, n: &usize) {
+        let x = candle_1d_pos(*n);
+        bencher.bench(|| x.log().unwrap());
+    }
+}
+
+#[divan::bench_group(name = "flex/sqrt")]
+mod flex_sqrt {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn sqrt(bencher: Bencher, n: &usize) {
+        let x = flex_1d_pos(*n);
+        bencher.bench(|| x.clone().sqrt());
+    }
+}
+#[divan::bench_group(name = "candle/sqrt")]
+mod candle_sqrt {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn sqrt(bencher: Bencher, n: &usize) {
+        let x = candle_1d_pos(*n);
+        bencher.bench(|| x.sqrt().unwrap());
+    }
+}
+
+#[divan::bench_group(name = "flex/recip")]
+mod flex_recip {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn recip(bencher: Bencher, n: &usize) {
+        let x = flex_1d_pos(*n);
+        bencher.bench(|| x.clone().recip());
+    }
+}
+#[divan::bench_group(name = "candle/recip")]
+mod candle_recip {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn recip(bencher: Bencher, n: &usize) {
+        let x = candle_1d_pos(*n);
+        bencher.bench(|| x.recip().unwrap());
+    }
+}
+
+#[divan::bench_group(name = "flex/abs")]
+mod flex_abs {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn abs(bencher: Bencher, n: &usize) {
+        let x = flex_1d(*n);
+        bencher.bench(|| x.clone().abs());
+    }
+}
+#[divan::bench_group(name = "candle/abs")]
+mod candle_abs {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn abs(bencher: Bencher, n: &usize) {
+        let x = candle_1d(*n);
+        bencher.bench(|| x.abs().unwrap());
+    }
+}
+
+#[divan::bench_group(name = "flex/neg")]
+mod flex_neg {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn neg(bencher: Bencher, n: &usize) {
+        let x = flex_1d(*n);
+        bencher.bench(|| x.clone().neg());
+    }
+}
+#[divan::bench_group(name = "candle/neg")]
+mod candle_neg {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn neg(bencher: Bencher, n: &usize) {
+        let x = candle_1d(*n);
+        bencher.bench(|| x.neg().unwrap());
+    }
+}
+
+#[divan::bench_group(name = "flex/tanh")]
+mod flex_tanh {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn tanh(bencher: Bencher, n: &usize) {
+        let x = flex_1d(*n);
+        bencher.bench(|| x.clone().tanh());
+    }
+}
+#[divan::bench_group(name = "candle/tanh")]
+mod candle_tanh {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn tanh(bencher: Bencher, n: &usize) {
+        let x = candle_1d(*n);
+        bencher.bench(|| x.tanh().unwrap());
+    }
+}
+
+#[divan::bench_group(name = "flex/sin")]
+mod flex_sin {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn sin(bencher: Bencher, n: &usize) {
+        let x = flex_1d(*n);
+        bencher.bench(|| x.clone().sin());
+    }
+}
+#[divan::bench_group(name = "candle/sin")]
+mod candle_sin {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn sin(bencher: Bencher, n: &usize) {
+        let x = candle_1d(*n);
+        bencher.bench(|| x.sin().unwrap());
+    }
+}
+
+#[divan::bench_group(name = "flex/cos")]
+mod flex_cos {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn cos(bencher: Bencher, n: &usize) {
+        let x = flex_1d(*n);
+        bencher.bench(|| x.clone().cos());
+    }
+}
+#[divan::bench_group(name = "candle/cos")]
+mod candle_cos {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn cos(bencher: Bencher, n: &usize) {
+        let x = candle_1d(*n);
+        bencher.bench(|| x.cos().unwrap());
+    }
+}
+
+// ============================================================================
+// Binary tensor-tensor
+// ============================================================================
+
+#[divan::bench_group(name = "flex/add")]
+mod flex_add {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn add(bencher: Bencher, n: &usize) {
+        let a = flex_1d(*n);
+        let b = flex_1d(*n);
+        bencher.bench(|| a.clone().add(b.clone()));
+    }
+}
+#[divan::bench_group(name = "candle/add")]
+mod candle_add {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn add(bencher: Bencher, n: &usize) {
+        let a = candle_1d(*n);
+        let b = candle_1d(*n);
+        bencher.bench(|| (&a + &b).unwrap());
+    }
+}
+
+#[divan::bench_group(name = "flex/sub")]
+mod flex_sub {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn sub(bencher: Bencher, n: &usize) {
+        let a = flex_1d(*n);
+        let b = flex_1d(*n);
+        bencher.bench(|| a.clone().sub(b.clone()));
+    }
+}
+#[divan::bench_group(name = "candle/sub")]
+mod candle_sub {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn sub(bencher: Bencher, n: &usize) {
+        let a = candle_1d(*n);
+        let b = candle_1d(*n);
+        bencher.bench(|| (&a - &b).unwrap());
+    }
+}
+
+#[divan::bench_group(name = "flex/mul")]
+mod flex_mul {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn mul(bencher: Bencher, n: &usize) {
+        let a = flex_1d(*n);
+        let b = flex_1d(*n);
+        bencher.bench(|| a.clone().mul(b.clone()));
+    }
+}
+#[divan::bench_group(name = "candle/mul")]
+mod candle_mul {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn mul(bencher: Bencher, n: &usize) {
+        let a = candle_1d(*n);
+        let b = candle_1d(*n);
+        bencher.bench(|| (&a * &b).unwrap());
+    }
+}
+
+#[divan::bench_group(name = "flex/div")]
+mod flex_div {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn div(bencher: Bencher, n: &usize) {
+        let a = flex_1d(*n);
+        let b = flex_1d_pos(*n);
+        bencher.bench(|| a.clone().div(b.clone()));
+    }
+}
+#[divan::bench_group(name = "candle/div")]
+mod candle_div {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn div(bencher: Bencher, n: &usize) {
+        let a = candle_1d(*n);
+        let b = candle_1d_pos(*n);
+        bencher.bench(|| (&a / &b).unwrap());
+    }
+}
+
+// ============================================================================
+// Binary tensor-scalar (candle maps this onto `affine(mul, add)`)
+// ============================================================================
+
+#[divan::bench_group(name = "flex/add_scalar")]
+mod flex_add_scalar {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn add_scalar(bencher: Bencher, n: &usize) {
+        let a = flex_1d(*n);
+        bencher.bench(|| a.clone().add_scalar(0.5));
+    }
+}
+#[divan::bench_group(name = "candle/add_scalar")]
+mod candle_add_scalar {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn add_scalar(bencher: Bencher, n: &usize) {
+        let a = candle_1d(*n);
+        // candle has no add_scalar; affine(1.0, 0.5) is the idiomatic form.
+        bencher.bench(|| a.affine(1.0, 0.5).unwrap());
+    }
+}
+
+#[divan::bench_group(name = "flex/mul_scalar")]
+mod flex_mul_scalar {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn mul_scalar(bencher: Bencher, n: &usize) {
+        let a = flex_1d(*n);
+        bencher.bench(|| a.clone().mul_scalar(2.5));
+    }
+}
+#[divan::bench_group(name = "candle/mul_scalar")]
+mod candle_mul_scalar {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn mul_scalar(bencher: Bencher, n: &usize) {
+        let a = candle_1d(*n);
+        bencher.bench(|| a.affine(2.5, 0.0).unwrap());
+    }
+}
+
+#[divan::bench_group(name = "flex/powf_scalar")]
+mod flex_powf_scalar {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn powf_scalar(bencher: Bencher, n: &usize) {
+        let a = flex_1d_pos(*n);
+        bencher.bench(|| a.clone().powf_scalar(2.5));
+    }
+}
+#[divan::bench_group(name = "candle/powf_scalar")]
+mod candle_powf_scalar {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn powf_scalar(bencher: Bencher, n: &usize) {
+        let a = candle_1d_pos(*n);
+        bencher.bench(|| a.powf(2.5).unwrap());
+    }
+}
+
+// ============================================================================
+// Comparison (result is bool/u8). Used heavily in masking paths.
+// ============================================================================
+
+#[divan::bench_group(name = "flex/greater")]
+mod flex_greater {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn greater(bencher: Bencher, n: &usize) {
+        let a = flex_1d(*n);
+        let b = flex_1d(*n);
+        bencher.bench(|| a.clone().greater(b.clone()));
+    }
+}
+#[divan::bench_group(name = "candle/greater")]
+mod candle_greater {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn greater(bencher: Bencher, n: &usize) {
+        let a = candle_1d(*n);
+        let b = candle_1d(*n);
+        bencher.bench(|| a.gt(&b).unwrap());
+    }
+}
+
+#[divan::bench_group(name = "flex/equal")]
+mod flex_equal {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn equal(bencher: Bencher, n: &usize) {
+        let a = flex_1d(*n);
+        let b = flex_1d(*n);
+        bencher.bench(|| a.clone().equal(b.clone()));
+    }
+}
+#[divan::bench_group(name = "candle/equal")]
+mod candle_equal {
+    use super::*;
+    #[divan::bench(args = SIZES)]
+    fn equal(bencher: Bencher, n: &usize) {
+        let a = candle_1d(*n);
+        let b = candle_1d(*n);
+        bencher.bench(|| a.eq(&b).unwrap());
+    }
+}

--- a/crates/burn-flex-bench-candle/benches/indexing.rs
+++ b/crates/burn-flex-bench-candle/benches/indexing.rs
@@ -1,0 +1,161 @@
+//! Indexing ops vs candle: gather, select (index_select), scatter_add,
+//! where_cond (mask_where).
+//!
+//! Run with:
+//! ```bash
+//! cargo bench -p burn-flex-bench-candle --bench indexing
+//! ```
+
+use burn_flex::Flex;
+use burn_tensor::{IndexingUpdateOp, Int, Tensor, TensorData};
+use candle_core::{DType as CDType, Device as CandleDevice, Tensor as CandleTensor};
+use divan::{AllocProfiler, Bencher};
+
+#[global_allocator]
+static ALLOC: AllocProfiler = AllocProfiler::system();
+
+fn main() {
+    println!("Indexing: burn-flex vs candle (pure Rust)");
+    println!();
+    divan::main();
+}
+
+fn fill(n: usize) -> Vec<f32> {
+    (0..n).map(|i| ((i % 1000) as f32 / 1000.0) - 0.5).collect()
+}
+
+fn flex_2d(rows: usize, cols: usize) -> Tensor<Flex, 2> {
+    Tensor::from_data(
+        TensorData::new(fill(rows * cols), [rows, cols]),
+        &Default::default(),
+    )
+}
+fn candle_2d(rows: usize, cols: usize) -> CandleTensor {
+    CandleTensor::from_vec(fill(rows * cols), (rows, cols), &CandleDevice::Cpu).unwrap()
+}
+
+fn flex_idx_2d(rows: usize, cols: usize, max_idx: usize) -> Tensor<Flex, 2, Int> {
+    let data: Vec<i64> = (0..rows * cols).map(|i| (i % max_idx) as i64).collect();
+    Tensor::from_data(TensorData::new(data, [rows, cols]), &Default::default())
+}
+fn flex_idx_1d(n: usize, max_idx: usize) -> Tensor<Flex, 1, Int> {
+    let data: Vec<i64> = (0..n).map(|i| (i % max_idx) as i64).collect();
+    Tensor::from_data(TensorData::new(data, [n]), &Default::default())
+}
+
+fn candle_idx_2d(rows: usize, cols: usize, max_idx: usize) -> CandleTensor {
+    let data: Vec<u32> = (0..rows * cols).map(|i| (i % max_idx) as u32).collect();
+    CandleTensor::from_vec(data, (rows, cols), &CandleDevice::Cpu).unwrap()
+}
+fn candle_idx_1d(n: usize, max_idx: usize) -> CandleTensor {
+    let data: Vec<u32> = (0..n).map(|i| (i % max_idx) as u32).collect();
+    CandleTensor::from_vec(data, n, &CandleDevice::Cpu).unwrap()
+}
+
+// ============================================================================
+// gather — indices tensor same rank as source, one index per output element.
+// ============================================================================
+
+#[divan::bench_group(name = "flex/gather_last")]
+mod flex_gather {
+    use super::*;
+    #[divan::bench(args = [256usize, 1024])]
+    fn gather(bencher: Bencher, n: usize) {
+        let x = flex_2d(n, n);
+        let idx = flex_idx_2d(n, n / 2, n);
+        bencher.bench(|| x.clone().gather(1, idx.clone()));
+    }
+}
+#[divan::bench_group(name = "candle/gather_last")]
+mod candle_gather {
+    use super::*;
+    #[divan::bench(args = [256usize, 1024])]
+    fn gather(bencher: Bencher, n: usize) {
+        let x = candle_2d(n, n);
+        let idx = candle_idx_2d(n, n / 2, n);
+        bencher.bench(|| x.gather(&idx, 1).unwrap());
+    }
+}
+
+// ============================================================================
+// index_select / select — 1D index over one dim.
+// ============================================================================
+
+#[divan::bench_group(name = "flex/select_dim0")]
+mod flex_select {
+    use super::*;
+    #[divan::bench(args = [256usize, 1024])]
+    fn select(bencher: Bencher, n: usize) {
+        let x = flex_2d(n, n);
+        let idx = flex_idx_1d(n / 2, n);
+        bencher.bench(|| x.clone().select(0, idx.clone()));
+    }
+}
+#[divan::bench_group(name = "candle/select_dim0")]
+mod candle_select {
+    use super::*;
+    #[divan::bench(args = [256usize, 1024])]
+    fn select(bencher: Bencher, n: usize) {
+        let x = candle_2d(n, n);
+        let idx = candle_idx_1d(n / 2, n);
+        bencher.bench(|| x.index_select(&idx, 0).unwrap());
+    }
+}
+
+// ============================================================================
+// scatter_add — same-rank indices, accumulates values into source.
+// ============================================================================
+
+#[divan::bench_group(name = "flex/scatter_add_last")]
+mod flex_scatter {
+    use super::*;
+    #[divan::bench(args = [256usize, 1024])]
+    fn scatter(bencher: Bencher, n: usize) {
+        let x = flex_2d(n, n);
+        let idx = flex_idx_2d(n, n / 2, n);
+        let vals = flex_2d(n, n / 2);
+        bencher.bench(|| {
+            x.clone()
+                .scatter(1, idx.clone(), vals.clone(), IndexingUpdateOp::Add)
+        });
+    }
+}
+#[divan::bench_group(name = "candle/scatter_add_last")]
+mod candle_scatter {
+    use super::*;
+    #[divan::bench(args = [256usize, 1024])]
+    fn scatter(bencher: Bencher, n: usize) {
+        let x = candle_2d(n, n);
+        let idx = candle_idx_2d(n, n / 2, n);
+        let vals = candle_2d(n, n / 2);
+        bencher.bench(|| x.scatter_add(&idx, &vals, 1).unwrap());
+    }
+}
+
+// ============================================================================
+// where_cond / mask_where — select between two tensors based on a bool mask.
+// ============================================================================
+
+#[divan::bench_group(name = "flex/where_cond")]
+mod flex_where {
+    use super::*;
+    #[divan::bench(args = [256usize, 1024])]
+    fn where_cond(bencher: Bencher, n: usize) {
+        let a = flex_2d(n, n);
+        let b = flex_2d(n, n);
+        let mask = a.clone().greater(b.clone());
+        bencher.bench(|| a.clone().mask_where(mask.clone(), b.clone()));
+    }
+}
+#[divan::bench_group(name = "candle/where_cond")]
+mod candle_where {
+    use super::*;
+    #[divan::bench(args = [256usize, 1024])]
+    fn where_cond(bencher: Bencher, n: usize) {
+        let a = candle_2d(n, n);
+        let b = candle_2d(n, n);
+        // a.gt(b) produces a u8 mask; where_cond picks a where mask is true else b.
+        let mask = a.gt(&b).unwrap().to_dtype(CDType::U8).unwrap();
+        bencher.bench(|| mask.where_cond(&a, &b).unwrap());
+    }
+}

--- a/crates/burn-flex-bench-candle/benches/matmul_batched.rs
+++ b/crates/burn-flex-bench-candle/benches/matmul_batched.rs
@@ -1,0 +1,141 @@
+//! Batched matmul vs candle: attention Q@K^T and A@V shapes.
+//!
+//! Run with:
+//! ```bash
+//! cargo bench -p burn-flex-bench-candle --bench matmul_batched
+//! ```
+//!
+//! wav2vec2-large attention uses 16 heads, head_dim=64.
+//! QK^T: [heads, seq, head_dim] @ [heads, head_dim, seq] -> [heads, seq, seq]
+//! AV:   [heads, seq, seq]      @ [heads, seq, head_dim] -> [heads, seq, head_dim]
+
+use burn_flex::Flex;
+use burn_tensor::{Tensor, TensorData};
+use candle_core::{Device as CandleDevice, Tensor as CandleTensor};
+use divan::{AllocProfiler, Bencher};
+
+#[global_allocator]
+static ALLOC: AllocProfiler = AllocProfiler::system();
+
+fn main() {
+    println!("Batched matmul: burn-flex vs candle (pure Rust)");
+    println!();
+    divan::main();
+}
+
+fn fill(n: usize) -> Vec<f32> {
+    (0..n).map(|i| ((i % 1000) as f32 / 1000.0) - 0.5).collect()
+}
+
+fn flex_3d(b: usize, m: usize, n: usize) -> Tensor<Flex, 3> {
+    Tensor::from_data(
+        TensorData::new(fill(b * m * n), [b, m, n]),
+        &Default::default(),
+    )
+}
+fn candle_3d(b: usize, m: usize, n: usize) -> CandleTensor {
+    CandleTensor::from_vec(fill(b * m * n), (b, m, n), &CandleDevice::Cpu).unwrap()
+}
+
+#[derive(Copy, Clone)]
+struct Shape {
+    batch: usize,
+    m: usize,
+    k: usize,
+    n: usize,
+    label: &'static str,
+}
+
+impl std::fmt::Display for Shape {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.label)
+    }
+}
+
+// wav2vec2-large: heads=16, head_dim=64. 1s audio -> seq=50, 3s -> seq=150.
+const SHAPES: &[Shape] = &[
+    // QK^T
+    Shape {
+        batch: 16,
+        m: 50,
+        k: 64,
+        n: 50,
+        label: "qk_1s",
+    },
+    Shape {
+        batch: 16,
+        m: 150,
+        k: 64,
+        n: 150,
+        label: "qk_3s",
+    },
+    // AV
+    Shape {
+        batch: 16,
+        m: 50,
+        k: 50,
+        n: 64,
+        label: "av_1s",
+    },
+    Shape {
+        batch: 16,
+        m: 150,
+        k: 150,
+        n: 64,
+        label: "av_3s",
+    },
+    // Larger batched matmul to stress the kernel past the microbench floor.
+    Shape {
+        batch: 32,
+        m: 128,
+        k: 128,
+        n: 128,
+        label: "batched_128",
+    },
+];
+
+#[divan::bench_group(name = "flex/batched")]
+mod flex_batched {
+    use super::*;
+    #[divan::bench(args = SHAPES)]
+    fn matmul(bencher: Bencher, s: &Shape) {
+        let a = flex_3d(s.batch, s.m, s.k);
+        let b = flex_3d(s.batch, s.k, s.n);
+        bencher.bench(|| a.clone().matmul(b.clone()));
+    }
+}
+#[divan::bench_group(name = "candle/batched")]
+mod candle_batched {
+    use super::*;
+    #[divan::bench(args = SHAPES)]
+    fn matmul(bencher: Bencher, s: &Shape) {
+        let a = candle_3d(s.batch, s.m, s.k);
+        let b = candle_3d(s.batch, s.k, s.n);
+        bencher.bench(|| a.matmul(&b).unwrap());
+    }
+}
+
+// A realistic attention step: Q@K^T is often called on a transposed K produced
+// as a view. We replicate that here to include the view-dispatch cost.
+#[divan::bench_group(name = "flex/qk_transposed_view")]
+mod flex_qk_transposed {
+    use super::*;
+    #[divan::bench(args = [(16, 50, 64), (16, 150, 64)])]
+    fn qk(bencher: Bencher, dims: (usize, usize, usize)) {
+        let (h, seq, hd) = dims;
+        let q = flex_3d(h, seq, hd);
+        let k = flex_3d(h, seq, hd);
+        bencher.bench(|| q.clone().matmul(k.clone().swap_dims(1, 2)));
+    }
+}
+#[divan::bench_group(name = "candle/qk_transposed_view")]
+mod candle_qk_transposed {
+    use super::*;
+    #[divan::bench(args = [(16, 50, 64), (16, 150, 64)])]
+    fn qk(bencher: Bencher, dims: (usize, usize, usize)) {
+        let (h, seq, hd) = dims;
+        let q = candle_3d(h, seq, hd);
+        let k = candle_3d(h, seq, hd);
+        bencher.bench(|| q.matmul(&k.transpose(1, 2).unwrap()).unwrap());
+    }
+}

--- a/crates/burn-flex-bench-candle/benches/misc_ops.rs
+++ b/crates/burn-flex-bench-candle/benches/misc_ops.rs
@@ -1,0 +1,168 @@
+//! Misc ops: interpolate (nearest2d), cumsum, sort.
+//!
+//! Run with:
+//! ```bash
+//! cargo bench -p burn-flex-bench-candle --bench misc_ops
+//! ```
+
+use burn_flex::Flex;
+use burn_tensor::{
+    Tensor, TensorData, module,
+    ops::{InterpolateMode, InterpolateOptions},
+};
+use candle_core::{Device as CandleDevice, Tensor as CandleTensor};
+use divan::{AllocProfiler, Bencher};
+
+#[global_allocator]
+static ALLOC: AllocProfiler = AllocProfiler::system();
+
+fn main() {
+    println!("Misc ops: burn-flex vs candle (pure Rust)");
+    println!();
+    divan::main();
+}
+
+fn fill(n: usize) -> Vec<f32> {
+    (0..n).map(|i| ((i % 1000) as f32 / 1000.0) - 0.5).collect()
+}
+
+fn flex_2d(rows: usize, cols: usize) -> Tensor<Flex, 2> {
+    Tensor::from_data(
+        TensorData::new(fill(rows * cols), [rows, cols]),
+        &Default::default(),
+    )
+}
+fn candle_2d(rows: usize, cols: usize) -> CandleTensor {
+    CandleTensor::from_vec(fill(rows * cols), (rows, cols), &CandleDevice::Cpu).unwrap()
+}
+
+fn flex_4d(b: usize, c: usize, h: usize, w: usize) -> Tensor<Flex, 4> {
+    Tensor::from_data(
+        TensorData::new(fill(b * c * h * w), [b, c, h, w]),
+        &Default::default(),
+    )
+}
+fn candle_4d(b: usize, c: usize, h: usize, w: usize) -> CandleTensor {
+    CandleTensor::from_vec(fill(b * c * h * w), (b, c, h, w), &CandleDevice::Cpu).unwrap()
+}
+
+// ============================================================================
+// interpolate nearest2d
+// ============================================================================
+
+#[derive(Copy, Clone)]
+struct Up {
+    label: &'static str,
+    b: usize,
+    c: usize,
+    h_in: usize,
+    w_in: usize,
+    h_out: usize,
+    w_out: usize,
+}
+
+impl std::fmt::Display for Up {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.label)
+    }
+}
+
+const UPS: &[Up] = &[
+    Up {
+        label: "upsample_2x_64",
+        b: 1,
+        c: 3,
+        h_in: 64,
+        w_in: 64,
+        h_out: 128,
+        w_out: 128,
+    },
+    Up {
+        label: "upsample_4x_32",
+        b: 1,
+        c: 3,
+        h_in: 32,
+        w_in: 32,
+        h_out: 128,
+        w_out: 128,
+    },
+    Up {
+        label: "downsample_256_to_128",
+        b: 1,
+        c: 3,
+        h_in: 256,
+        w_in: 256,
+        h_out: 128,
+        w_out: 128,
+    },
+];
+
+#[divan::bench_group(name = "flex/nearest2d")]
+mod flex_nearest {
+    use super::*;
+    #[divan::bench(args = UPS)]
+    fn nearest(bencher: Bencher, u: &Up) {
+        let x = flex_4d(u.b, u.c, u.h_in, u.w_in);
+        let opts = InterpolateOptions::new(InterpolateMode::Nearest);
+        bencher.bench(|| module::interpolate(x.clone(), [u.h_out, u.w_out], opts.clone()));
+    }
+}
+#[divan::bench_group(name = "candle/nearest2d")]
+mod candle_nearest {
+    use super::*;
+    #[divan::bench(args = UPS)]
+    fn nearest(bencher: Bencher, u: &Up) {
+        let x = candle_4d(u.b, u.c, u.h_in, u.w_in);
+        bencher.bench(|| x.upsample_nearest2d(u.h_out, u.w_out).unwrap());
+    }
+}
+
+// ============================================================================
+// cumsum — prefix sum along a dim.
+// ============================================================================
+
+#[divan::bench_group(name = "flex/cumsum_last")]
+mod flex_cumsum {
+    use super::*;
+    #[divan::bench(args = [(256usize, 256usize), (1024, 1024)])]
+    fn cumsum(bencher: Bencher, dims: (usize, usize)) {
+        let (r, c) = dims;
+        let x = flex_2d(r, c);
+        bencher.bench(|| x.clone().cumsum(1));
+    }
+}
+#[divan::bench_group(name = "candle/cumsum_last")]
+mod candle_cumsum {
+    use super::*;
+    #[divan::bench(args = [(256usize, 256usize), (1024, 1024)])]
+    fn cumsum(bencher: Bencher, dims: (usize, usize)) {
+        let (r, c) = dims;
+        let x = candle_2d(r, c);
+        bencher.bench(|| x.cumsum(1).unwrap());
+    }
+}
+
+// ============================================================================
+// sort — candle only has sort_last_dim, so we mirror that on burn.
+// ============================================================================
+
+#[divan::bench_group(name = "flex/sort_last")]
+mod flex_sort {
+    use super::*;
+    #[divan::bench(args = [(256usize, 256usize), (1024, 1024)])]
+    fn sort(bencher: Bencher, dims: (usize, usize)) {
+        let (r, c) = dims;
+        let x = flex_2d(r, c);
+        bencher.bench(|| x.clone().sort(1));
+    }
+}
+#[divan::bench_group(name = "candle/sort_last")]
+mod candle_sort {
+    use super::*;
+    #[divan::bench(args = [(256usize, 256usize), (1024, 1024)])]
+    fn sort(bencher: Bencher, dims: (usize, usize)) {
+        let (r, c) = dims;
+        let x = candle_2d(r, c);
+        bencher.bench(|| x.sort_last_dim(true).unwrap());
+    }
+}

--- a/crates/burn-flex-bench-candle/benches/pool2d.rs
+++ b/crates/burn-flex-bench-candle/benches/pool2d.rs
@@ -1,0 +1,155 @@
+//! max_pool2d + avg_pool2d vs candle (pure Rust).
+//!
+//! Run with:
+//! ```bash
+//! cargo bench -p burn-flex-bench-candle --bench pool2d
+//! ```
+//!
+//! Candle's pool API only takes a kernel size and stride (no padding / no
+//! dilation), so we stick to zero-padding, dilation=1 configs on both sides.
+
+use burn_flex::Flex;
+use burn_tensor::{Tensor, TensorData, module};
+use candle_core::{Device as CandleDevice, Tensor as CandleTensor};
+use divan::{AllocProfiler, Bencher};
+
+#[global_allocator]
+static ALLOC: AllocProfiler = AllocProfiler::system();
+
+fn main() {
+    println!("Pool2d: burn-flex vs candle (pure Rust)");
+    println!();
+    divan::main();
+}
+
+fn fill(n: usize) -> Vec<f32> {
+    (0..n).map(|i| ((i % 1000) as f32 / 1000.0) - 0.5).collect()
+}
+
+fn flex_in(b: usize, c: usize, h: usize, w: usize) -> Tensor<Flex, 4> {
+    Tensor::from_data(
+        TensorData::new(fill(b * c * h * w), [b, c, h, w]),
+        &Default::default(),
+    )
+}
+fn candle_in(b: usize, c: usize, h: usize, w: usize) -> CandleTensor {
+    CandleTensor::from_vec(fill(b * c * h * w), (b, c, h, w), &CandleDevice::Cpu).unwrap()
+}
+
+#[derive(Copy, Clone)]
+struct P {
+    name: &'static str,
+    b: usize,
+    c: usize,
+    h: usize,
+    w: usize,
+    k: usize,
+    stride: usize,
+}
+
+impl std::fmt::Display for P {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.name)
+    }
+}
+
+const POOLS: &[P] = &[
+    P {
+        name: "k2s2_64x56",
+        b: 1,
+        c: 64,
+        h: 56,
+        w: 56,
+        k: 2,
+        stride: 2,
+    },
+    P {
+        name: "k2s2_128x28",
+        b: 1,
+        c: 128,
+        h: 28,
+        w: 28,
+        k: 2,
+        stride: 2,
+    },
+    P {
+        name: "k3s2_64x112",
+        b: 1,
+        c: 64,
+        h: 112,
+        w: 112,
+        k: 3,
+        stride: 2,
+    },
+    P {
+        name: "k3s2_batch8_64x56",
+        b: 8,
+        c: 64,
+        h: 56,
+        w: 56,
+        k: 3,
+        stride: 2,
+    },
+];
+
+#[divan::bench_group(name = "flex/max_pool2d")]
+mod flex_max_pool {
+    use super::*;
+    #[divan::bench(args = POOLS)]
+    fn max_pool2d(bencher: Bencher, p: &P) {
+        let x = flex_in(p.b, p.c, p.h, p.w);
+        bencher.bench(|| {
+            module::max_pool2d(
+                x.clone(),
+                [p.k, p.k],
+                [p.stride, p.stride],
+                [0, 0],
+                [1, 1],
+                false,
+            )
+        });
+    }
+}
+#[divan::bench_group(name = "candle/max_pool2d")]
+mod candle_max_pool {
+    use super::*;
+    #[divan::bench(args = POOLS)]
+    fn max_pool2d(bencher: Bencher, p: &P) {
+        let x = candle_in(p.b, p.c, p.h, p.w);
+        bencher.bench(|| {
+            x.max_pool2d_with_stride((p.k, p.k), (p.stride, p.stride))
+                .unwrap()
+        });
+    }
+}
+
+#[divan::bench_group(name = "flex/avg_pool2d")]
+mod flex_avg_pool {
+    use super::*;
+    #[divan::bench(args = POOLS)]
+    fn avg_pool2d(bencher: Bencher, p: &P) {
+        let x = flex_in(p.b, p.c, p.h, p.w);
+        bencher.bench(|| {
+            module::avg_pool2d(
+                x.clone(),
+                [p.k, p.k],
+                [p.stride, p.stride],
+                [0, 0],
+                false,
+                false,
+            )
+        });
+    }
+}
+#[divan::bench_group(name = "candle/avg_pool2d")]
+mod candle_avg_pool {
+    use super::*;
+    #[divan::bench(args = POOLS)]
+    fn avg_pool2d(bencher: Bencher, p: &P) {
+        let x = candle_in(p.b, p.c, p.h, p.w);
+        bencher.bench(|| {
+            x.avg_pool2d_with_stride((p.k, p.k), (p.stride, p.stride))
+                .unwrap()
+        });
+    }
+}

--- a/crates/burn-flex-bench-candle/benches/reduce.rs
+++ b/crates/burn-flex-bench-candle/benches/reduce.rs
@@ -1,0 +1,280 @@
+//! Reductions vs candle (pure Rust).
+//!
+//! Run with:
+//! ```bash
+//! cargo bench -p burn-flex-bench-candle --bench reduce
+//! ```
+//!
+//! Reductions along the *last* dim are the common SIMD-friendly case;
+//! reductions along a non-last dim are where many backends lose performance
+//! because the inner stride is larger than 1.
+
+use burn_flex::Flex;
+use burn_tensor::{Tensor, TensorData};
+use candle_core::{Device as CandleDevice, Tensor as CandleTensor};
+use divan::{AllocProfiler, Bencher};
+
+#[global_allocator]
+static ALLOC: AllocProfiler = AllocProfiler::system();
+
+fn main() {
+    println!("Reductions: burn-flex vs candle (pure Rust)");
+    println!();
+    divan::main();
+}
+
+fn fill(n: usize) -> Vec<f32> {
+    (0..n).map(|i| ((i % 1000) as f32 / 1000.0) - 0.5).collect()
+}
+
+fn flex_2d(rows: usize, cols: usize) -> Tensor<Flex, 2> {
+    Tensor::from_data(
+        TensorData::new(fill(rows * cols), [rows, cols]),
+        &Default::default(),
+    )
+}
+
+fn candle_2d(rows: usize, cols: usize) -> CandleTensor {
+    CandleTensor::from_vec(fill(rows * cols), (rows, cols), &CandleDevice::Cpu).unwrap()
+}
+
+#[derive(Copy, Clone)]
+struct Shape {
+    rows: usize,
+    cols: usize,
+    label: &'static str,
+}
+
+impl std::fmt::Display for Shape {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.label)
+    }
+}
+
+/// Square-ish and transformer-ish shapes.
+const SHAPES: &[Shape] = &[
+    Shape {
+        rows: 256,
+        cols: 256,
+        label: "256x256",
+    },
+    Shape {
+        rows: 1024,
+        cols: 1024,
+        label: "1024x1024",
+    },
+    Shape {
+        rows: 150,
+        cols: 1024,
+        label: "hidden_3s",
+    },
+    Shape {
+        rows: 150,
+        cols: 4096,
+        label: "ffn_3s",
+    },
+];
+
+// ============================================================================
+// Full reductions
+// ============================================================================
+
+#[divan::bench_group(name = "flex/sum")]
+mod flex_sum {
+    use super::*;
+    #[divan::bench(args = SHAPES)]
+    fn sum(bencher: Bencher, s: &Shape) {
+        let x = flex_2d(s.rows, s.cols);
+        bencher.bench(|| x.clone().sum());
+    }
+}
+#[divan::bench_group(name = "candle/sum")]
+mod candle_sum {
+    use super::*;
+    #[divan::bench(args = SHAPES)]
+    fn sum(bencher: Bencher, s: &Shape) {
+        let x = candle_2d(s.rows, s.cols);
+        bencher.bench(|| x.sum_all().unwrap());
+    }
+}
+
+#[divan::bench_group(name = "flex/mean")]
+mod flex_mean {
+    use super::*;
+    #[divan::bench(args = SHAPES)]
+    fn mean(bencher: Bencher, s: &Shape) {
+        let x = flex_2d(s.rows, s.cols);
+        bencher.bench(|| x.clone().mean());
+    }
+}
+#[divan::bench_group(name = "candle/mean")]
+mod candle_mean {
+    use super::*;
+    #[divan::bench(args = SHAPES)]
+    fn mean(bencher: Bencher, s: &Shape) {
+        let x = candle_2d(s.rows, s.cols);
+        bencher.bench(|| x.mean_all().unwrap());
+    }
+}
+
+#[divan::bench_group(name = "flex/max")]
+mod flex_max {
+    use super::*;
+    #[divan::bench(args = SHAPES)]
+    fn max(bencher: Bencher, s: &Shape) {
+        let x = flex_2d(s.rows, s.cols);
+        bencher.bench(|| x.clone().max());
+    }
+}
+#[divan::bench_group(name = "candle/max")]
+mod candle_max {
+    use super::*;
+    #[divan::bench(args = SHAPES)]
+    fn max(bencher: Bencher, s: &Shape) {
+        let x = candle_2d(s.rows, s.cols);
+        // Max over all dims: reduce dim 0 then dim 0 of result.
+        bencher.bench(|| x.flatten_all().unwrap().max(0).unwrap());
+    }
+}
+
+#[divan::bench_group(name = "flex/min")]
+mod flex_min {
+    use super::*;
+    #[divan::bench(args = SHAPES)]
+    fn min(bencher: Bencher, s: &Shape) {
+        let x = flex_2d(s.rows, s.cols);
+        bencher.bench(|| x.clone().min());
+    }
+}
+#[divan::bench_group(name = "candle/min")]
+mod candle_min {
+    use super::*;
+    #[divan::bench(args = SHAPES)]
+    fn min(bencher: Bencher, s: &Shape) {
+        let x = candle_2d(s.rows, s.cols);
+        bencher.bench(|| x.flatten_all().unwrap().min(0).unwrap());
+    }
+}
+
+// ============================================================================
+// Dim reductions — last dim (cols). This is the fast path: inner stride = 1.
+// ============================================================================
+
+#[divan::bench_group(name = "flex/sum_last")]
+mod flex_sum_last {
+    use super::*;
+    #[divan::bench(args = SHAPES)]
+    fn sum_dim(bencher: Bencher, s: &Shape) {
+        let x = flex_2d(s.rows, s.cols);
+        bencher.bench(|| x.clone().sum_dim(1));
+    }
+}
+#[divan::bench_group(name = "candle/sum_last")]
+mod candle_sum_last {
+    use super::*;
+    #[divan::bench(args = SHAPES)]
+    fn sum_dim(bencher: Bencher, s: &Shape) {
+        let x = candle_2d(s.rows, s.cols);
+        bencher.bench(|| x.sum_keepdim(1).unwrap());
+    }
+}
+
+#[divan::bench_group(name = "flex/mean_last")]
+mod flex_mean_last {
+    use super::*;
+    #[divan::bench(args = SHAPES)]
+    fn mean_dim(bencher: Bencher, s: &Shape) {
+        let x = flex_2d(s.rows, s.cols);
+        bencher.bench(|| x.clone().mean_dim(1));
+    }
+}
+#[divan::bench_group(name = "candle/mean_last")]
+mod candle_mean_last {
+    use super::*;
+    #[divan::bench(args = SHAPES)]
+    fn mean_dim(bencher: Bencher, s: &Shape) {
+        let x = candle_2d(s.rows, s.cols);
+        bencher.bench(|| x.mean_keepdim(1).unwrap());
+    }
+}
+
+#[divan::bench_group(name = "flex/max_last")]
+mod flex_max_last {
+    use super::*;
+    #[divan::bench(args = SHAPES)]
+    fn max_dim(bencher: Bencher, s: &Shape) {
+        let x = flex_2d(s.rows, s.cols);
+        bencher.bench(|| x.clone().max_dim(1));
+    }
+}
+#[divan::bench_group(name = "candle/max_last")]
+mod candle_max_last {
+    use super::*;
+    #[divan::bench(args = SHAPES)]
+    fn max_dim(bencher: Bencher, s: &Shape) {
+        let x = candle_2d(s.rows, s.cols);
+        bencher.bench(|| x.max_keepdim(1).unwrap());
+    }
+}
+
+#[divan::bench_group(name = "flex/argmax_last")]
+mod flex_argmax_last {
+    use super::*;
+    #[divan::bench(args = SHAPES)]
+    fn argmax(bencher: Bencher, s: &Shape) {
+        let x = flex_2d(s.rows, s.cols);
+        bencher.bench(|| x.clone().argmax(1));
+    }
+}
+#[divan::bench_group(name = "candle/argmax_last")]
+mod candle_argmax_last {
+    use super::*;
+    #[divan::bench(args = SHAPES)]
+    fn argmax(bencher: Bencher, s: &Shape) {
+        let x = candle_2d(s.rows, s.cols);
+        bencher.bench(|| x.argmax_keepdim(1).unwrap());
+    }
+}
+
+// ============================================================================
+// Dim reductions — non-last dim (rows). Inner stride = cols, which stresses
+// the backend's ability to vectorize across non-unit strides.
+// ============================================================================
+
+#[divan::bench_group(name = "flex/sum_first")]
+mod flex_sum_first {
+    use super::*;
+    #[divan::bench(args = SHAPES)]
+    fn sum_dim(bencher: Bencher, s: &Shape) {
+        let x = flex_2d(s.rows, s.cols);
+        bencher.bench(|| x.clone().sum_dim(0));
+    }
+}
+#[divan::bench_group(name = "candle/sum_first")]
+mod candle_sum_first {
+    use super::*;
+    #[divan::bench(args = SHAPES)]
+    fn sum_dim(bencher: Bencher, s: &Shape) {
+        let x = candle_2d(s.rows, s.cols);
+        bencher.bench(|| x.sum_keepdim(0).unwrap());
+    }
+}
+
+#[divan::bench_group(name = "flex/max_first")]
+mod flex_max_first {
+    use super::*;
+    #[divan::bench(args = SHAPES)]
+    fn max_dim(bencher: Bencher, s: &Shape) {
+        let x = flex_2d(s.rows, s.cols);
+        bencher.bench(|| x.clone().max_dim(0));
+    }
+}
+#[divan::bench_group(name = "candle/max_first")]
+mod candle_max_first {
+    use super::*;
+    #[divan::bench(args = SHAPES)]
+    fn max_dim(bencher: Bencher, s: &Shape) {
+        let x = candle_2d(s.rows, s.cols);
+        bencher.bench(|| x.max_keepdim(0).unwrap());
+    }
+}

--- a/crates/burn-flex-bench-candle/benches/shape_ops.rs
+++ b/crates/burn-flex-bench-candle/benches/shape_ops.rs
@@ -1,0 +1,261 @@
+//! Shape / layout ops vs candle: transpose, reshape, narrow, expand, cat,
+//! repeat, permute, flip.
+//!
+//! Run with:
+//! ```bash
+//! cargo bench -p burn-flex-bench-candle --bench shape_ops
+//! ```
+//!
+//! Transpose/reshape/narrow/expand/permute are normally O(1) view operations
+//! on both backends; these benches measure view-creation overhead plus any
+//! materialization the backend chooses to do. `cat` and `repeat` always copy.
+
+use burn_flex::Flex;
+use burn_tensor::{Tensor, TensorData};
+use candle_core::{Device as CandleDevice, Tensor as CandleTensor};
+use divan::{AllocProfiler, Bencher};
+
+#[global_allocator]
+static ALLOC: AllocProfiler = AllocProfiler::system();
+
+fn main() {
+    println!("Shape ops: burn-flex vs candle (pure Rust)");
+    println!();
+    divan::main();
+}
+
+fn fill(n: usize) -> Vec<f32> {
+    (0..n).map(|i| ((i % 1000) as f32 / 1000.0) - 0.5).collect()
+}
+
+fn flex_2d(rows: usize, cols: usize) -> Tensor<Flex, 2> {
+    Tensor::from_data(
+        TensorData::new(fill(rows * cols), [rows, cols]),
+        &Default::default(),
+    )
+}
+fn flex_3d(d0: usize, d1: usize, d2: usize) -> Tensor<Flex, 3> {
+    Tensor::from_data(
+        TensorData::new(fill(d0 * d1 * d2), [d0, d1, d2]),
+        &Default::default(),
+    )
+}
+fn candle_2d(rows: usize, cols: usize) -> CandleTensor {
+    CandleTensor::from_vec(fill(rows * cols), (rows, cols), &CandleDevice::Cpu).unwrap()
+}
+fn candle_3d(d0: usize, d1: usize, d2: usize) -> CandleTensor {
+    CandleTensor::from_vec(fill(d0 * d1 * d2), (d0, d1, d2), &CandleDevice::Cpu).unwrap()
+}
+
+// ============================================================================
+// transpose / swap_dims — view op, so this is pure overhead measurement.
+// ============================================================================
+
+#[divan::bench_group(name = "flex/transpose")]
+mod flex_transpose {
+    use super::*;
+    #[divan::bench(args = [256, 1024])]
+    fn transpose(bencher: Bencher, n: usize) {
+        let x = flex_2d(n, n);
+        bencher.bench(|| x.clone().swap_dims(0, 1));
+    }
+}
+#[divan::bench_group(name = "candle/transpose")]
+mod candle_transpose {
+    use super::*;
+    #[divan::bench(args = [256, 1024])]
+    fn transpose(bencher: Bencher, n: usize) {
+        let x = candle_2d(n, n);
+        bencher.bench(|| x.t().unwrap());
+    }
+}
+
+// Transpose followed by a unary exp forces both backends to actually walk the
+// non-contiguous layout. This is where strided traversal cost shows up.
+#[divan::bench_group(name = "flex/transpose_then_exp")]
+mod flex_transpose_then_exp {
+    use super::*;
+    #[divan::bench(args = [256, 1024])]
+    fn transpose_exp(bencher: Bencher, n: usize) {
+        let x = flex_2d(n, n);
+        bencher.bench(|| x.clone().swap_dims(0, 1).exp());
+    }
+}
+#[divan::bench_group(name = "candle/transpose_then_exp")]
+mod candle_transpose_then_exp {
+    use super::*;
+    #[divan::bench(args = [256, 1024])]
+    fn transpose_exp(bencher: Bencher, n: usize) {
+        let x = candle_2d(n, n);
+        bencher.bench(|| x.t().unwrap().exp().unwrap());
+    }
+}
+
+// ============================================================================
+// reshape — typically a view, but may materialize if layout isn't contiguous.
+// ============================================================================
+
+#[divan::bench_group(name = "flex/reshape")]
+mod flex_reshape {
+    use super::*;
+    #[divan::bench(args = [(256, 256), (1024, 1024)])]
+    fn reshape(bencher: Bencher, dims: (usize, usize)) {
+        let (r, c) = dims;
+        let x = flex_2d(r, c);
+        bencher.bench(|| x.clone().reshape([r * c]));
+    }
+}
+#[divan::bench_group(name = "candle/reshape")]
+mod candle_reshape {
+    use super::*;
+    #[divan::bench(args = [(256, 256), (1024, 1024)])]
+    fn reshape(bencher: Bencher, dims: (usize, usize)) {
+        let (r, c) = dims;
+        let x = candle_2d(r, c);
+        bencher.bench(|| x.reshape((r * c,)).unwrap());
+    }
+}
+
+// ============================================================================
+// narrow / slice
+// ============================================================================
+
+#[divan::bench_group(name = "flex/narrow")]
+mod flex_narrow {
+    use super::*;
+    #[divan::bench]
+    fn narrow_1024(bencher: Bencher) {
+        let x = flex_2d(1024, 1024);
+        bencher.bench(|| x.clone().slice([0..512, 0..512]));
+    }
+}
+#[divan::bench_group(name = "candle/narrow")]
+mod candle_narrow {
+    use super::*;
+    #[divan::bench]
+    fn narrow_1024(bencher: Bencher) {
+        let x = candle_2d(1024, 1024);
+        bencher.bench(|| {
+            x.narrow(0, 0, 512)
+                .and_then(|t| t.narrow(1, 0, 512))
+                .unwrap()
+        });
+    }
+}
+
+// ============================================================================
+// expand / broadcast_as
+// ============================================================================
+
+#[divan::bench_group(name = "flex/expand")]
+mod flex_expand {
+    use super::*;
+    #[divan::bench]
+    fn expand_row_1024(bencher: Bencher) {
+        let x: Tensor<Flex, 2> =
+            Tensor::from_data(TensorData::new(fill(1024), [1, 1024]), &Default::default());
+        bencher.bench(|| x.clone().expand([1024, 1024]));
+    }
+}
+#[divan::bench_group(name = "candle/expand")]
+mod candle_expand {
+    use super::*;
+    #[divan::bench]
+    fn expand_row_1024(bencher: Bencher) {
+        let x = CandleTensor::from_vec(fill(1024), (1, 1024), &CandleDevice::Cpu).unwrap();
+        bencher.bench(|| x.broadcast_as((1024, 1024)).unwrap());
+    }
+}
+
+// ============================================================================
+// cat — always materializes. This is the interesting one.
+// ============================================================================
+
+#[divan::bench_group(name = "flex/cat_dim0")]
+mod flex_cat_dim0 {
+    use super::*;
+    #[divan::bench]
+    fn cat_2x_1024(bencher: Bencher) {
+        let a = flex_2d(1024, 1024);
+        let b = flex_2d(1024, 1024);
+        bencher.bench(|| Tensor::cat(vec![a.clone(), b.clone()], 0));
+    }
+}
+#[divan::bench_group(name = "candle/cat_dim0")]
+mod candle_cat_dim0 {
+    use super::*;
+    #[divan::bench]
+    fn cat_2x_1024(bencher: Bencher) {
+        let a = candle_2d(1024, 1024);
+        let b = candle_2d(1024, 1024);
+        bencher.bench(|| CandleTensor::cat(&[&a, &b], 0).unwrap());
+    }
+}
+
+#[divan::bench_group(name = "flex/cat_last")]
+mod flex_cat_last {
+    use super::*;
+    #[divan::bench]
+    fn cat_2x_1024(bencher: Bencher) {
+        let a = flex_2d(1024, 1024);
+        let b = flex_2d(1024, 1024);
+        bencher.bench(|| Tensor::cat(vec![a.clone(), b.clone()], 1));
+    }
+}
+#[divan::bench_group(name = "candle/cat_last")]
+mod candle_cat_last {
+    use super::*;
+    #[divan::bench]
+    fn cat_2x_1024(bencher: Bencher) {
+        let a = candle_2d(1024, 1024);
+        let b = candle_2d(1024, 1024);
+        bencher.bench(|| CandleTensor::cat(&[&a, &b], 1).unwrap());
+    }
+}
+
+// ============================================================================
+// repeat_dim / repeat
+// ============================================================================
+
+#[divan::bench_group(name = "flex/repeat_dim")]
+mod flex_repeat {
+    use super::*;
+    #[divan::bench]
+    fn repeat_256_4x(bencher: Bencher) {
+        let x = flex_2d(256, 256);
+        bencher.bench(|| x.clone().repeat_dim(0, 4));
+    }
+}
+#[divan::bench_group(name = "candle/repeat_dim")]
+mod candle_repeat {
+    use super::*;
+    #[divan::bench]
+    fn repeat_256_4x(bencher: Bencher) {
+        let x = candle_2d(256, 256);
+        // candle's `repeat` takes a shape-like multiplier.
+        bencher.bench(|| x.repeat((4, 1)).unwrap());
+    }
+}
+
+// ============================================================================
+// permute — 3D swap-two-dims variant
+// ============================================================================
+
+#[divan::bench_group(name = "flex/permute_3d")]
+mod flex_permute {
+    use super::*;
+    #[divan::bench]
+    fn permute_64x128x256(bencher: Bencher) {
+        let x = flex_3d(64, 128, 256);
+        bencher.bench(|| x.clone().permute([2, 0, 1]));
+    }
+}
+#[divan::bench_group(name = "candle/permute_3d")]
+mod candle_permute {
+    use super::*;
+    #[divan::bench]
+    fn permute_64x128x256(bencher: Bencher) {
+        let x = candle_3d(64, 128, 256);
+        bencher.bench(|| x.permute((2, 0, 1)).unwrap());
+    }
+}


### PR DESCRIPTION
## Summary

This branch bundles three perf-related efforts that all landed in the same cycle:

- **conv weight transpose fix** (`crates/burn-flex/src/ops/conv.rs`). Rewrote the `(c_in, K) → (K, c_in)` transpose inside `conv3d_impl` as a tight `K`-inner loop that LLVM autovectorizes. For small-shape conv this loop was ~80% of runtime. Moves wav2vec2-large feature extractor from candle 1.21× ahead to flex 1.12× ahead on Apple M3 Max. Biggest single gain is L0 (~15% faster) and L6 (~47% faster).

- **Fused softmax + layer_norm** (`crates/burn-flex/src/ops/activation.rs`). Adds single-pass row kernels dispatched via macerator. Bypasses the 5-6-op decomposition that every burn user gets today from `burn_tensor::activation::softmax` / `burn::nn::LayerNorm::forward`. At wav2vec2 attention shapes, fused softmax is 40× faster than decomposed and 1.5× faster than candle; fused layer_norm is 7× faster than decomposed and 1.6-3.6× faster than candle. `UPSTREAM_ISSUE.md` drafts a proposal to add trait hooks to burn-backend so any CPU backend can plug in.

- **burn-flex-bench-candle crate** with 11 bench targets covering every flex op that intersects with candle's CPU API: matmul, conv1d, transformer_ops (pre-existing), plus elementwise, reduce, shape_ops, matmul_batched, conv2d, pool2d, indexing, misc_ops (added in the final commit). `BENCHMARKS_CANDLE.md` holds the full breakdown with per-category tables and a prioritized perf bug list surfaced by the broader coverage (10 items, conv_transpose2d the biggest at 8× slower than candle).

Also bumps candle-core + candle-nn to 0.10 and a few small formatting/review-feedback commits that accumulated during the activation work.

## Headline numbers (Apple M3 Max, pure-Rust, no BLAS)

| Area                          | Flex vs Candle            |
| ----------------------------- | ------------------------- |
| wav2vec2 feature extractor    | **1.10×** (flex ahead)    |
| softmax (fused) attn 3s       | **1.45×**                 |
| layer_norm (fused) 50×1024    | **3.59×**                 |
| Batched matmul 32×128×128²    | **13.0×**                 |
| conv2d ResNet layer 2         | **1.85×**                 |
| max_pool2d k=3 s=2            | **2.05-2.64×**            |
| cumsum last dim               | **6-10×**                 |
| Full max/min                  | **4.0×**                  |
| sum along non-last dim        | **15.3×**                 |
| gather last dim               | **2.09×**                 |
| Elementwise + square matmul   | tied (memory-bandwidth)   |

## Known regressions (documented and prioritized in BENCHMARKS_CANDLE.md)

1. conv_transpose2d 8× slower
2. sort_last at 1024² 8× slower
3. max_dim / argmax_dim 4× slower
4. matmul on transposed-view input at small seq 4× slower than candle and 6× slower than flex's own contiguous path
5. index_select, where_cond, last-axis sum/mean each ~2× slower

## Test plan

- [ ] `cargo test -p burn-flex` (all unit tests pass including new activation tests and softmax dtype/rayon coverage)
- [ ] `cargo test -p burn-flex --no-default-features` (no_std path)
- [ ] `cargo test -p burn-flex --no-default-features --features simd` (no_std + SIMD)
- [ ] `cargo bench -p burn-flex-bench-candle --no-run` (all 11 bench targets compile)
- [ ] Miri: `cargo +nightly miri test -p burn-flex` (validates fused softmax/layer_norm pointer arithmetic and output-buffer init fix)
- [ ] `burn-backend-tests` conformance suite passes against flex
- [ ] wav2vec2-large real-model inference on `burn-flex-worktree`