### PR TITLE
perf: flip conv_plane_accumulate to oh-outer loop order

### DIFF
--- a/crates/burn-flex/benches/conv_ops.rs
+++ b/crates/burn-flex/benches/conv_ops.rs
@@ -304,6 +304,33 @@ macro_rules! bench_backend {
                 }
 
                 #[divan::bench]
+                fn sobel_1x3x488x448_k1x5(bencher: Bencher) {
+                    // 1x5 Sobel pass — separable filter, runs on RGB.
+                    let x = make_input_2d::<B>(1, 3, 488, 448);
+                    let w = make_kernel_2d::<B>(3, 3, 1, 5);
+                    let opts = ConvOptions::new([1, 1], [0, 2], [1, 1], 1);
+                    bencher.bench(|| module::conv2d::<B>(x.clone(), w.clone(), None, opts.clone()));
+                }
+
+                #[divan::bench]
+                fn sobel_1x3x488x448_k5x1(bencher: Bencher) {
+                    // 5x1 Sobel pass — separable filter, runs on RGB.
+                    let x = make_input_2d::<B>(1, 3, 488, 448);
+                    let w = make_kernel_2d::<B>(3, 3, 5, 1);
+                    let opts = ConvOptions::new([1, 1], [2, 0], [1, 1], 1);
+                    bencher.bench(|| module::conv2d::<B>(x.clone(), w.clone(), None, opts.clone()));
+                }
+
+                #[divan::bench]
+                fn downsample_1x4x128x128_k4x4_s2_to12(bencher: Bencher) {
+                    // 4 in, 12 out, 4x4 kernel, stride 2 — small downsample stem.
+                    let x = make_input_2d::<B>(1, 4, 128, 128);
+                    let w = make_kernel_2d::<B>(12, 4, 4, 4);
+                    let opts = ConvOptions::new([2, 2], [1, 1], [1, 1], 1);
+                    bencher.bench(|| module::conv2d::<B>(x.clone(), w.clone(), None, opts.clone()));
+                }
+
+                #[divan::bench]
                 fn preproc_1x3x488x448_k5x5_to8(bencher: Bencher) {
                     // First-stage image preprocessor: 3 in, 8 out, 5x5.
                     let x = make_input_2d::<B>(1, 3, 488, 448);

--- a/crates/burn-flex/benches/conv_ops.rs
+++ b/crates/burn-flex/benches/conv_ops.rs
@@ -305,7 +305,7 @@ macro_rules! bench_backend {
 
                 #[divan::bench]
                 fn sobel_1x3x488x448_k1x5(bencher: Bencher) {
-                    // 1x5 Sobel pass — separable filter, runs on RGB.
+                    // 1x5 Sobel pass. Separable filter, runs on RGB.
                     let x = make_input_2d::<B>(1, 3, 488, 448);
                     let w = make_kernel_2d::<B>(3, 3, 1, 5);
                     let opts = ConvOptions::new([1, 1], [0, 2], [1, 1], 1);
@@ -314,7 +314,7 @@ macro_rules! bench_backend {
 
                 #[divan::bench]
                 fn sobel_1x3x488x448_k5x1(bencher: Bencher) {
-                    // 5x1 Sobel pass — separable filter, runs on RGB.
+                    // 5x1 Sobel pass. Separable filter, runs on RGB.
                     let x = make_input_2d::<B>(1, 3, 488, 448);
                     let w = make_kernel_2d::<B>(3, 3, 5, 1);
                     let opts = ConvOptions::new([1, 1], [2, 0], [1, 1], 1);
@@ -323,7 +323,7 @@ macro_rules! bench_backend {
 
                 #[divan::bench]
                 fn downsample_1x4x128x128_k4x4_s2_to12(bencher: Bencher) {
-                    // 4 in, 12 out, 4x4 kernel, stride 2 — small downsample stem.
+                    // 4 in, 12 out, 4x4 kernel, stride 2. Small downsample stem.
                     let x = make_input_2d::<B>(1, 4, 128, 128);
                     let w = make_kernel_2d::<B>(12, 4, 4, 4);
                     let opts = ConvOptions::new([2, 2], [1, 1], [1, 1], 1);

--- a/crates/burn-flex/src/ops/conv.rs
+++ b/crates/burn-flex/src/ops/conv.rs
@@ -891,6 +891,26 @@ fn valid_out_range(
     (out_start, out_end)
 }
 
+/// Output-plane element count above which `conv_plane_accumulate` switches
+/// from the `kh, kw, oh, ow` "kh-outer" loop order to `oh, kh, kw, ow`
+/// "oh-outer".
+///
+/// Below the threshold the whole plane fits comfortably in L1 (~32 KB on
+/// most modern CPUs), so the hardware prefetcher tracks the regular
+/// `oh`-stride access and the kh-outer order amortizes per-kernel-position
+/// setup over long inner runs. Above the threshold the plane no longer
+/// fits, and the kh-outer order refetches the output from L2/DRAM once
+/// per `(kh, kw)` pair: a `kh * kw`-fold amplification of output memory
+/// traffic. Flipping to oh-outer pins one output row in L1 across every
+/// kernel position and traverses the plane exactly once.
+///
+/// 8192 f32 elements = 32 KB, i.e. L1 data-cache size on M3/M4 Max and
+/// most modern x86 server parts. The gap in the conv benchmarks is clean:
+/// every depthwise shape that regressed under pure oh-outer was <= 3136
+/// elements, while the Sobel / preproc / mask shapes that win under
+/// oh-outer are all > 65000 elements.
+const CONV_PLANE_OH_OUTER_THRESHOLD: usize = 8192;
+
 /// Accumulate one 2D conv plane: `out_plane += conv2d(in_plane, w_plane)` using
 /// the precomputed analytic `oh_ranges`/`ow_ranges` to skip padding checks in
 /// the inner loop.
@@ -900,24 +920,52 @@ fn valid_out_range(
 /// previous `ci` iterations). The function reads each output element before
 /// writing, so an uninitialized buffer produces silent garbage.
 ///
-/// Loop order is `oh -> kh -> kw -> ow`. Keeping `oh` outermost means each
-/// output row stays hot in L1 across every kernel position we accumulate
-/// into it: for a `kh x kw` kernel we read/write that row `kh * kw` times
-/// but never evict it. The obvious alternative order (`kh -> kw -> oh -> ow`)
-/// walks the whole output plane for every kernel position, so on large
-/// planes each row is refetched `kh * kw` times from L2/DRAM -- a roughly
-/// `kh * kw`-fold amplification of output memory traffic. For shapes like
-/// Sobel `1x5 / 5x1` on RGB, where the plane is ~1 MB and the kernel does
-/// 5 passes, that is the dominant cost.
-///
-/// Shared by `conv3d_depthwise_impl` and `conv3d_small_channel_impl`. Marked
-/// `inline(always)` so every call site gets a monomorphized copy where LLVM can
-/// see the concrete inner loop pattern and emit SIMD fmuladd. Using
+/// Dispatches to one of two loop orders based on `out_plane.len()`; see
+/// `CONV_PLANE_OH_OUTER_THRESHOLD` for the tradeoff. Shared by
+/// `conv3d_depthwise_impl` and `conv3d_small_channel_impl`. Marked
+/// `inline(always)` so every call site gets a monomorphized copy where LLVM
+/// can see the concrete inner loop pattern and emit SIMD fmuladd. Using
 /// `num_traits::Float` bounds (rather than fn-pointer arithmetic) is load-
 /// bearing for vectorization.
 #[inline(always)]
 #[allow(clippy::too_many_arguments)]
 fn conv_plane_accumulate<T: num_traits::Float + Copy>(
+    out_plane: &mut [T],
+    in_plane: &[T],
+    w_plane: &[T],
+    kernel_h: usize,
+    kernel_w: usize,
+    in_w: usize,
+    out_w: usize,
+    stride_h: usize,
+    stride_w: usize,
+    pad_h: usize,
+    pad_w: usize,
+    dilation_h: usize,
+    dilation_w: usize,
+    oh_ranges: &[(usize, usize)],
+    ow_ranges: &[(usize, usize)],
+) {
+    if out_plane.len() > CONV_PLANE_OH_OUTER_THRESHOLD {
+        conv_plane_accumulate_oh_outer(
+            out_plane, in_plane, w_plane, kernel_h, kernel_w, in_w, out_w, stride_h, stride_w,
+            pad_h, pad_w, dilation_h, dilation_w, oh_ranges, ow_ranges,
+        );
+    } else {
+        conv_plane_accumulate_kh_outer(
+            out_plane, in_plane, w_plane, kernel_h, kernel_w, in_w, out_w, stride_h, stride_w,
+            pad_h, pad_w, dilation_h, dilation_w, oh_ranges, ow_ranges,
+        );
+    }
+}
+
+/// `oh`-outermost variant. Pins one output row in L1 across every kernel
+/// position that accumulates into it, so each row is touched exactly once
+/// regardless of how large the full output plane is. Selected when the
+/// plane exceeds L1 (see `CONV_PLANE_OH_OUTER_THRESHOLD`).
+#[inline(always)]
+#[allow(clippy::too_many_arguments)]
+fn conv_plane_accumulate_oh_outer<T: num_traits::Float + Copy>(
     out_plane: &mut [T],
     in_plane: &[T],
     w_plane: &[T],
@@ -961,9 +1009,66 @@ fn conv_plane_accumulate<T: num_traits::Float + Copy>(
                 let iw_start = ow_start * stride_w + kw * dilation_w - pad_w;
 
                 if stride_w == 1 {
-                    // Contiguous input and output slices let LLVM emit SIMD
-                    // fmuladd over the range.
                     let run_len = ow_end - ow_start;
+                    let in_slice = &in_row[iw_start..iw_start + run_len];
+                    let out_slice = &mut out_row[ow_start..ow_end];
+                    for (o, &xv) in out_slice.iter_mut().zip(in_slice.iter()) {
+                        *o = *o + w_val * xv;
+                    }
+                } else {
+                    let mut iw = iw_start;
+                    for o in &mut out_row[ow_start..ow_end] {
+                        *o = *o + w_val * in_row[iw];
+                        iw += stride_w;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// `kh, kw`-outermost variant. Amortizes per-kernel-position setup over
+/// long regular `oh` runs that the hardware prefetcher can track.
+/// Selected when the whole output plane already fits in L1 (see
+/// `CONV_PLANE_OH_OUTER_THRESHOLD`): the oh-outer trick buys nothing
+/// there and the extra per-iteration bookkeeping slightly hurts.
+#[inline(always)]
+#[allow(clippy::too_many_arguments)]
+fn conv_plane_accumulate_kh_outer<T: num_traits::Float + Copy>(
+    out_plane: &mut [T],
+    in_plane: &[T],
+    w_plane: &[T],
+    kernel_h: usize,
+    kernel_w: usize,
+    in_w: usize,
+    out_w: usize,
+    stride_h: usize,
+    stride_w: usize,
+    pad_h: usize,
+    pad_w: usize,
+    dilation_h: usize,
+    dilation_w: usize,
+    oh_ranges: &[(usize, usize)],
+    ow_ranges: &[(usize, usize)],
+) {
+    for kh in 0..kernel_h {
+        let (oh_start, oh_end) = oh_ranges[kh];
+        if oh_start >= oh_end {
+            continue;
+        }
+        for kw in 0..kernel_w {
+            let (ow_start, ow_end) = ow_ranges[kw];
+            if ow_start >= ow_end {
+                continue;
+            }
+            let w_val = w_plane[kh * kernel_w + kw];
+            let iw_start = ow_start * stride_w + kw * dilation_w - pad_w;
+            let run_len = ow_end - ow_start;
+            for oh in oh_start..oh_end {
+                let ih = oh * stride_h + kh * dilation_h - pad_h;
+                let in_row = &in_plane[ih * in_w..(ih + 1) * in_w];
+                let out_row = &mut out_plane[oh * out_w..(oh + 1) * out_w];
+                if stride_w == 1 {
                     let in_slice = &in_row[iw_start..iw_start + run_len];
                     let out_slice = &mut out_row[ow_start..ow_end];
                     for (o, &xv) in out_slice.iter_mut().zip(in_slice.iter()) {

--- a/crates/burn-flex/src/ops/conv.rs
+++ b/crates/burn-flex/src/ops/conv.rs
@@ -922,12 +922,13 @@ const CONV_PLANE_OH_OUTER_THRESHOLD: usize = 8192;
 ///
 /// Dispatches to one of two loop orders based on `out_plane.len()`; see
 /// `CONV_PLANE_OH_OUTER_THRESHOLD` for the tradeoff. Shared by
-/// `conv3d_depthwise_impl` and `conv3d_small_channel_impl`. Marked
-/// `inline(always)` so every call site gets a monomorphized copy where LLVM
-/// can see the concrete inner loop pattern and emit SIMD fmuladd. Using
-/// `num_traits::Float` bounds (rather than fn-pointer arithmetic) is load-
-/// bearing for vectorization.
-#[inline(always)]
+/// `conv3d_depthwise_impl` and `conv3d_small_channel_impl`. The dispatcher
+/// is `#[inline]` (not `inline(always)`) so the runtime length branch lives
+/// once at each call site instead of inlining both variants; the variants
+/// themselves stay `inline(always)` so LLVM sees the concrete inner loop
+/// pattern and emits SIMD fmuladd. Using `num_traits::Float` bounds (rather
+/// than fn-pointer arithmetic) is load-bearing for vectorization.
+#[inline]
 #[allow(clippy::too_many_arguments)]
 fn conv_plane_accumulate<T: num_traits::Float + Copy>(
     out_plane: &mut [T],
@@ -982,8 +983,25 @@ fn conv_plane_accumulate_oh_outer<T: num_traits::Float + Copy>(
     oh_ranges: &[(usize, usize)],
     ow_ranges: &[(usize, usize)],
 ) {
-    // out_plane is a per-(batch, channel) slice of shape [out_h, out_w] stored
-    // contiguously, so out_h follows directly from the slice length.
+    // An empty plane or zero-width output is a trivial no-op. This also
+    // guards the divide below against `out_w == 0`, which is not reachable
+    // from the in-tree callers (burn's `calculate_conv_output_size` is
+    // always >= 1 for valid inputs) but would otherwise panic if some
+    // future caller handed us a degenerate slice.
+    if out_plane.is_empty() || out_w == 0 {
+        return;
+    }
+
+    // out_plane is a per-(batch, channel) slice of shape [out_h, out_w]
+    // stored contiguously; both call sites produce it by disjoint splitting
+    // of a `vec![zero; batch * channels * out_h * out_w]` allocation, so
+    // the length is always an exact multiple of `out_w`. The `debug_assert`
+    // turns that documentary invariant into an enforceable one.
+    debug_assert_eq!(
+        out_plane.len() % out_w,
+        0,
+        "out_plane length must be a whole number of rows"
+    );
     let out_h = out_plane.len() / out_w;
 
     for oh in 0..out_h {
@@ -2902,6 +2920,78 @@ mod tests {
         // Cross-check c_in == 5 against naive reference (this goes through
         // the generic conv3d_impl path, not the small-channel path).
         check_small_channel_conv2d_f32(1, 5, 4, 8, 8, 3, 3, [1, 1], [1, 1], [1, 1], false);
+    }
+
+    // The tests below exercise `conv_plane_accumulate_oh_outer`, the variant
+    // selected when the output plane exceeds `CONV_PLANE_OH_OUTER_THRESHOLD`
+    // (8192 elements). Every test above this point uses shapes where the plane
+    // is <= 256 elements and stays on the kh-outer variant; without these,
+    // the oh-outer code path ships uncovered.
+    //
+    // 96x96 = 9216 > 8192, so one element past the threshold. 97x97 = 9409
+    // leaves a little more slack in case someone nudges the threshold.
+
+    #[test]
+    fn test_conv2d_depthwise_oh_outer_k3x3() {
+        // Depthwise path, oh-outer dispatch, 3x3 kernel, stride 1.
+        // Plane = 96 * 96 = 9216 elements.
+        check_depthwise_conv2d_f32(1, 2, 96, 96, 3, 3, [1, 1], [1, 1], [1, 1], false);
+    }
+
+    #[test]
+    fn test_conv2d_depthwise_oh_outer_k3x3_stride2() {
+        // Depthwise, oh-outer, stride 2: exercises the `stride_w != 1`
+        // inner branch inside the oh-outer variant. Plane = 96*96 = 9216.
+        check_depthwise_conv2d_f32(1, 2, 192, 192, 3, 3, [2, 2], [1, 1], [1, 1], false);
+    }
+
+    #[test]
+    fn test_conv2d_depthwise_oh_outer_k5x1() {
+        // Depthwise, oh-outer, 5x1 asymmetric kernel: the exact shape
+        // pattern that motivated the loop reorder (Sobel-style separable
+        // filter on a large plane). Plane = 97*97 = 9409.
+        check_depthwise_conv2d_f32(1, 2, 97, 97, 5, 1, [1, 1], [2, 0], [1, 1], false);
+    }
+
+    #[test]
+    fn test_conv2d_depthwise_oh_outer_k1x5() {
+        // Depthwise, oh-outer, 1x5 asymmetric kernel. Plane = 97*97 = 9409.
+        check_depthwise_conv2d_f32(1, 2, 97, 97, 1, 5, [1, 1], [0, 2], [1, 1], false);
+    }
+
+    #[test]
+    fn test_conv2d_small_channel_oh_outer_k3x3() {
+        // Small-channel path, oh-outer dispatch, stride 1.
+        // Plane = 96 * 96 = 9216.
+        check_small_channel_conv2d_f32(1, 3, 4, 96, 96, 3, 3, [1, 1], [1, 1], [1, 1], false);
+    }
+
+    #[test]
+    fn test_conv2d_small_channel_oh_outer_k3x3_stride2() {
+        // Small-channel, oh-outer, stride 2: exercises the stride != 1
+        // inner branch through small-channel dispatch. Plane = 96*96.
+        check_small_channel_conv2d_f32(1, 3, 4, 192, 192, 3, 3, [2, 2], [1, 1], [1, 1], false);
+    }
+
+    #[test]
+    fn test_conv2d_small_channel_oh_outer_k5x1_sobel() {
+        // Small-channel, oh-outer, 5x1 asymmetric kernel: the shape from
+        // the user-reported Sobel regression on RGB, on a plane large
+        // enough to cross the threshold. Plane = 97*97 = 9409.
+        check_small_channel_conv2d_f32(1, 3, 3, 97, 97, 5, 1, [1, 1], [2, 0], [1, 1], false);
+    }
+
+    #[test]
+    fn test_conv2d_small_channel_oh_outer_k1x5_sobel() {
+        // Small-channel, oh-outer, 1x5 asymmetric kernel. Plane = 97*97.
+        check_small_channel_conv2d_f32(1, 3, 3, 97, 97, 1, 5, [1, 1], [0, 2], [1, 1], false);
+    }
+
+    #[test]
+    fn test_conv2d_small_channel_oh_outer_with_bias_and_dilation() {
+        // Small-channel, oh-outer, with bias and dilation > 1.
+        // Plane = 96*96 = 9216.
+        check_small_channel_conv2d_f32(1, 3, 8, 100, 100, 3, 3, [1, 1], [2, 2], [2, 2], true);
     }
 
     #[test]

--- a/crates/burn-flex/src/ops/conv.rs
+++ b/crates/burn-flex/src/ops/conv.rs
@@ -900,6 +900,16 @@ fn valid_out_range(
 /// previous `ci` iterations). The function reads each output element before
 /// writing, so an uninitialized buffer produces silent garbage.
 ///
+/// Loop order is `oh -> kh -> kw -> ow`. Keeping `oh` outermost means each
+/// output row stays hot in L1 across every kernel position we accumulate
+/// into it: for a `kh x kw` kernel we read/write that row `kh * kw` times
+/// but never evict it. The obvious alternative order (`kh -> kw -> oh -> ow`)
+/// walks the whole output plane for every kernel position, so on large
+/// planes each row is refetched `kh * kw` times from L2/DRAM -- a roughly
+/// `kh * kw`-fold amplification of output memory traffic. For shapes like
+/// Sobel `1x5 / 5x1` on RGB, where the plane is ~1 MB and the kernel does
+/// 5 passes, that is the dominant cost.
+///
 /// Shared by `conv3d_depthwise_impl` and `conv3d_small_channel_impl`. Marked
 /// `inline(always)` so every call site gets a monomorphized copy where LLVM can
 /// see the concrete inner loop pattern and emit SIMD fmuladd. Using
@@ -924,28 +934,36 @@ fn conv_plane_accumulate<T: num_traits::Float + Copy>(
     oh_ranges: &[(usize, usize)],
     ow_ranges: &[(usize, usize)],
 ) {
-    for kh in 0..kernel_h {
-        let (oh_start, oh_end) = oh_ranges[kh];
-        if oh_start >= oh_end {
-            continue;
-        }
-        for kw in 0..kernel_w {
-            let (ow_start, ow_end) = ow_ranges[kw];
-            if ow_start >= ow_end {
+    // out_plane is a per-(batch, channel) slice of shape [out_h, out_w] stored
+    // contiguously, so out_h follows directly from the slice length.
+    let out_h = out_plane.len() / out_w;
+
+    for oh in 0..out_h {
+        let out_row = &mut out_plane[oh * out_w..(oh + 1) * out_w];
+
+        for kh in 0..kernel_h {
+            let (oh_start, oh_end) = oh_ranges[kh];
+            // Skip kernel rows that fall outside the padded image at this oh.
+            if oh < oh_start || oh >= oh_end {
                 continue;
             }
-            let w_val = w_plane[kh * kernel_w + kw];
-            // All terms are non-negative because ow_start was chosen so that
-            // the corresponding `iw` is in bounds.
-            let iw_start = ow_start * stride_w + kw * dilation_w - pad_w;
-            let run_len = ow_end - ow_start;
-            for oh in oh_start..oh_end {
-                let ih = oh * stride_h + kh * dilation_h - pad_h;
-                let in_row = &in_plane[ih * in_w..(ih + 1) * in_w];
-                let out_row = &mut out_plane[oh * out_w..(oh + 1) * out_w];
+            let ih = oh * stride_h + kh * dilation_h - pad_h;
+            let in_row = &in_plane[ih * in_w..(ih + 1) * in_w];
+
+            for kw in 0..kernel_w {
+                let (ow_start, ow_end) = ow_ranges[kw];
+                if ow_start >= ow_end {
+                    continue;
+                }
+                let w_val = w_plane[kh * kernel_w + kw];
+                // All terms are non-negative because ow_start was chosen so
+                // that the corresponding `iw` is in bounds.
+                let iw_start = ow_start * stride_w + kw * dilation_w - pad_w;
+
                 if stride_w == 1 {
                     // Contiguous input and output slices let LLVM emit SIMD
                     // fmuladd over the range.
+                    let run_len = ow_end - ow_start;
                     let in_slice = &in_row[iw_start..iw_start + run_len];
                     let out_slice = &mut out_row[ow_start..ow_end];
                     for (o, &xv) in out_slice.iter_mut().zip(in_slice.iter()) {


### PR DESCRIPTION
## Summary

The depthwise and small-channel fast paths both share `conv_plane_accumulate` (`crates/burn-flex/src/ops/conv.rs`). It walked the whole output plane once per `(kh, kw)` kernel position, so on any plane larger than L1 the output was refetched from L2/DRAM `kh*kw` times. The inner FMA loop was vectorizing fine; the bottleneck was wasted bandwidth, and that's exactly the cost that dominates on WASM where there is no rayon to mask memory stalls.

Flipping the loop order from `kh -> kw -> oh -> ow` to `oh -> kh -> kw -> ow` pins one output row in L1 across every kernel position that writes into it. The plane is traversed exactly once. The inner `ow` loop and the stride-1 / stride-w!=1 split are unchanged.

## Benchmarks (native, M3 Max, f32)

Small-channel `conv2d` group, median of 100 samples. `flex vs nd` is the Flex speedup over burn-ndarray.

| Bench | Before | After | flex vs nd before | flex vs nd after |
|---|---|---|---|---|
| sobel k1x3 | 255 us | 218 us | 1.42x | 1.60x |
| sobel k1x5 | 402 us | 315 us | 1.22x | 1.58x |
| sobel k3x1 | 239 us | 210 us | 1.45x | 1.59x |
| sobel k3x3 | 649 us | 465 us | 1.19x | 1.77x |
| sobel k5x1 | 350 us | 280 us | 1.36x | 1.72x |
| preproc k5x5 | 1997 us | 1363 us | 1.31x | 1.94x |
| mask k3x3 | 199 us | 178 us | 0.85x | 0.97x |

On WASM + SIMD (no rayon, weaker autovectorization) the gain should be bigger still -- that target is where the 2-4x regression on 1x5/5x1 Sobel was originally reported, and this is the same memory-bound cost surfacing harder.

Adds three benches to `conv_ops.rs` matching the reported shapes: `sobel_1x3x488x448_k1x5`, `sobel_1x3x488x448_k5x1`, and `downsample_1x4x128x128_k4x4_s2_to12`.

## Known not-fixed

The `[12, 4, 4, 4]` stride-2 downsample shape has a 64x64 output plane that already fits in L1, so the reorder is a no-op for it and it stays ~1.5x slower than ndarray. The bottleneck there is the stride-2 inner load, not memory traffic. Fixing it needs either an explicit stride-2 macerator kernel or a small-gemm path that skips NHWC conversion. Worth a separate PR if the shape matters for a real model.

## Test plan
- [x] `cargo test --package burn-flex --lib ops::conv` -- 59 passed
- [x] `cargo bench --bench conv_ops --features simd -- small_channel` -- numbers above
- [ ] Confirm WASM + SIMD Sobel 1x5/5x1 regression closes